### PR TITLE
Added reconnection logic for server side

### DIFF
--- a/.github/workflows/docker-mir-multi.yaml
+++ b/.github/workflows/docker-mir-multi.yaml
@@ -81,6 +81,18 @@ jobs:
           echo "Time: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "User: ${{ github.actor }}"
 
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=Mir IoT Hub
+            org.opencontainers.image.description=Comprehensive IoT platform for secure device communication, telemetry collection, and command execution
+            org.opencontainers.image.vendor=maxthom
+            org.opencontainers.image.documentation=https://book.mirhub.io
+            org.opencontainers.image.licenses=Apache-2.0
+
       - name: Build and push multi-platform Docker image
         id: build
         uses: docker/build-push-action@v6
@@ -90,6 +102,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 # Runtime stage
 FROM alpine:3.19
 
+# Add metadata labels
+LABEL org.opencontainers.image.title="Mir IoT Hub"
+LABEL org.opencontainers.image.description="Comprehensive IoT platform for secure device communication, telemetry collection, and command execution"
+LABEL org.opencontainers.image.authors="maxthom"
+LABEL org.opencontainers.image.source="https://github.com/maxthom/mir"
+LABEL org.opencontainers.image.documentation="https://book.mirhub.io"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="maxthom"
+
 # Install runtime dependencies
 RUN apk add --no-cache \
     ca-certificates \

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,36 +9,42 @@
 ### Features
 
 - [ ] Search by wildcard
-- [ ] Grafana Dashboard for eventstore
-- [x] Docker container
-  - [x] Multibuild
-  - [x] Simple
-- [x] Pipeline for each
-- [x] CLI Tool template
-  - [x] new command to generate config of device
-  - [x] serve up with Mir
 - [ ] MCP Server for Mir
-- [ ] autoreconnect
-  - [ ] nats
-    - [ ] Check if Mir is running with a command reply
-      - [ ] Check for tlm
-      - [ ] Check for core
-      - [ ] Check for cfg
-  - [x] on startup
-    - [x] surreal
-    - [x] influx
-  - [ ] during
-    - [ ] surreal
-      - [ ] running in degraded state
-      - [ ] core, doesnt work anymore
-      - [ ] cfg, doesnt work anymore
-      - [ ] cmd, can work if same schema
-      - [ ] tlm, can work if same schema
-    - [x] influx
-      - [x] recreate org/bucket
-      - [x] already reconnect and has a buffer
-            - can we increase it?
-            - add better status log
+- [ ] Road to Production
+  - [ ] Grafana Dashboard for eventstore
+  - [ ] HelmChart
+  - [ ] GrafanaLoki
+  - [x] Docker container
+    - [ ] Simple/Multi for device
+    - [x] Multibuild
+    - [x] Simple
+  - [ ] Pipeline for each
+    - [ ] For device
+    - [x] For server
+  - [x] CLI Tool template
+    - [x] new command to generate config of device
+    - [x] serve up with Mir
+  - [ ] autoreconnect
+    - [ ] nats
+      - [ ] Check if Mir is running with a command reply
+        - [ ] Check for tlm
+        - [ ] Check for core
+        - [ ] Check for cfg
+    - [x] on startup
+      - [x] surreal
+      - [x] influx
+    - [ ] during
+      - [ ] surreal
+        - [ ] running in degraded state
+        - [ ] core, doesnt work anymore
+        - [ ] cfg, doesnt work anymore
+        - [ ] cmd, can work if same schema
+        - [ ] tlm, can work if same schema
+      - [x] influx
+        - [x] recreate org/bucket
+        - [x] already reconnect and has a buffer
+              - can we increase it?
+              - add better status log
 ### Refactoring
 
 ### Documentation
@@ -49,6 +55,7 @@
 - [ ] Update MdBook to latest version
 - [x] Mir Concepts
 - [ ] DeviceConfiguration
+- [ ] Talk about reconnection and network loss
 
 ### Ergonomics
 
@@ -77,7 +84,7 @@
 - [ ] DeviceSDK
   - [x] Msg store
   - [ ] Host metrics https://github.com/shirou/gopsutil
-  - [ ] Buf documentation/template
+  - [x] Buf documentation/template
   - [x] DeviceID (MAC, random, etc [save to kv store])
   - [x] Custom Routes
 - [ ] ModuleSDK

--- a/TASKS.md
+++ b/TASKS.md
@@ -10,7 +10,11 @@
 
 - [ ] Search by wildcard
 - [ ] Grafana Dashboard for eventstore
-- [ ] CLI Tool template
+- [x] Docker container
+  - [x] Multibuild
+  - [x] Simple
+- [x] Pipeline for each
+- [x] CLI Tool template
   - [x] new command to generate config of device
   - [x] serve up with Mir
 - [ ] MCP Server for Mir

--- a/TASKS.md
+++ b/TASKS.md
@@ -29,8 +29,14 @@
     - [x] influx
   - [ ] during
     - [ ] surreal
-    - [ ] influx
-      - [ ] already reconnect and has a buffer
+      - [ ] running in degraded state
+      - [ ] core, doesnt work anymore
+      - [ ] cfg, doesnt work anymore
+      - [ ] cmd, can work if same schema
+      - [ ] tlm, can work if same schema
+    - [x] influx
+      - [x] recreate org/bucket
+      - [x] already reconnect and has a buffer
             - can we increase it?
             - add better status log
 ### Refactoring
@@ -42,6 +48,7 @@
 - [x] DeviceSDK with buf
 - [ ] Update MdBook to latest version
 - [x] Mir Concepts
+- [ ] DeviceConfiguration
 
 ### Ergonomics
 
@@ -54,6 +61,7 @@
   - [x] Dashboards
   - [ ] Alerts & Alarm with Grafana and Influx
   - [x] Dashboards with influx/surreal/grafana data
+  - [ ] Grafana Loki for logs
 - [ ] Productions
   - [ ] Docker
   - [ ] Template container for device sdk

--- a/TASKS.md
+++ b/TASKS.md
@@ -26,21 +26,25 @@
     - [x] serve up with Mir
   - [ ] autoreconnect
     - [ ] nats
-      - [ ] Check if Mir is running with a command reply
-        - [ ] Check for tlm
-        - [ ] Check for core
-        - [ ] Check for cfg
+      - [x] nats
     - [x] on startup
       - [x] surreal
       - [x] influx
     - [ ] during
       - [ ] surreal
         - [ ] running in degraded state
-        - [ ] core, doesnt work anymore
-        - [ ] cfg, doesnt work anymore
-        - [ ] cmd, can work if same schema
-        - [ ] tlm, can work if same schema
-      - [x] influx
+        - [x] core, doesnt work anymore
+        - [x] cfg, list can work
+        - [x] cmd, can work if same schema
+        - [x] tlm, can work if same schema
+        - [ ] accumulate events in a buffer, event from cmd
+            - [ ] Add that events can be sent without related object
+            - [ ] Have a event buffer
+            - [ ] events
+              - [ ] online
+              - [ ] offline
+              - [ ] cmd send
+       - [x] influx
         - [x] recreate org/bucket
         - [x] already reconnect and has a buffer
               - can we increase it?
@@ -109,3 +113,15 @@
 - [ ] Scope in namespace
 - [ ] Service in trigger chain
 - [ ] Autotwin template
+- [ ] nats
+  - [ ] Check if Mir is running with a command reply
+    - [ ] Check for tlm, if down set to storage
+    - [ ] Check for core
+    - [ ] Check for cfg, if down
+    - [ ] Check for cmd
+  - [ ] Solution
+    - [ ] part of hearthbeat as reply/request
+    - [ ] core keep status of running services and can return system status
+    - [ ] if core, cfg or tlm down, set local persistence
+    - [ ] if cfg degraded, set local persistence
+    - [ ] each service, need a health route, part of sdk

--- a/cmds/core/main.go
+++ b/cmds/core/main.go
@@ -18,12 +18,10 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/core_srv"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -157,15 +155,22 @@ func run(
 
 	// Setup
 	// Database
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.DatabaseServer.Url, cfg.DatabaseServer.Namespace, cfg.DatabaseServer.Database, cfg.DatabaseServer.User, cfg.DatabaseServer.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+	db, err := surreal.Connect(ctx, cfg.DatabaseServer.Url,
+		cfg.DatabaseServer.Namespace,
+		cfg.DatabaseServer.Database,
+		cfg.DatabaseServer.User,
+		cfg.DatabaseServer.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Error().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	// Bus
 	m, err := mir.Connect(AppName, cfg.DataBusServer.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)

--- a/cmds/eventstore/main.go
+++ b/cmds/eventstore/main.go
@@ -18,12 +18,10 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/eventstore_srv"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -157,16 +155,22 @@ func run(
 
 	// Setup
 	// Database
-
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.DatabaseServer.Url, cfg.DatabaseServer.Namespace, cfg.DatabaseServer.Database, cfg.DatabaseServer.User, cfg.DatabaseServer.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+	db, err := surreal.Connect(ctx, cfg.DatabaseServer.Url,
+		cfg.DatabaseServer.Namespace,
+		cfg.DatabaseServer.Database,
+		cfg.DatabaseServer.User,
+		cfg.DatabaseServer.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Error().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	// Bus
 	m, err := mir.Connect(AppName, cfg.DataBusServer.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)

--- a/cmds/protocfg/main.go
+++ b/cmds/protocfg/main.go
@@ -18,13 +18,11 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/protocfg_srv"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -158,15 +156,22 @@ func run(
 
 	// Setup
 	// Database
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.DatabaseServer.Url, cfg.DatabaseServer.Namespace, cfg.DatabaseServer.Database, cfg.DatabaseServer.User, cfg.DatabaseServer.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+	db, err := surreal.Connect(ctx, cfg.DatabaseServer.Url,
+		cfg.DatabaseServer.Namespace,
+		cfg.DatabaseServer.Database,
+		cfg.DatabaseServer.User,
+		cfg.DatabaseServer.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Error().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	// Bus
 	m, err := mir.Connect(AppName, cfg.DataBusServer.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)

--- a/cmds/protocmd/main.go
+++ b/cmds/protocmd/main.go
@@ -18,13 +18,11 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/protocmd_srv"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -158,15 +156,22 @@ func run(
 
 	// Setup
 	// Database
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.DatabaseServer.Url, cfg.DatabaseServer.Namespace, cfg.DatabaseServer.Database, cfg.DatabaseServer.User, cfg.DatabaseServer.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+	db, err := surreal.Connect(ctx, cfg.DatabaseServer.Url,
+		cfg.DatabaseServer.Namespace,
+		cfg.DatabaseServer.Database,
+		cfg.DatabaseServer.User,
+		cfg.DatabaseServer.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Error().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	// Bus
 	m, err := mir.Connect(AppName, cfg.DataBusServer.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)

--- a/cmds/prototlm/main.go
+++ b/cmds/prototlm/main.go
@@ -194,7 +194,7 @@ func run(
 				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
 			},
 			FnDisconnected: func(url string) {
-				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database, running in degraded state")
+				log.Error().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database, running in degraded state")
 			},
 			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
 				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
@@ -265,7 +265,7 @@ func run(
 	}()
 
 	if err := prototlmSrv.Serve(); err != nil {
-		panic(err)
+		return err
 	}
 
 	// Handle shutdown

--- a/cmds/prototlm/main.go
+++ b/cmds/prototlm/main.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
-	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/externals/ts"
 	"github.com/maxthom/mir/internal/libs/api/health"
@@ -99,7 +99,7 @@ var (
 
 			BatchSize:        1000,               // Number of datapoints
 			FlushInterval:    1000,               // 1sec
-			RetryBufferLimit: 1000 * 1024 * 1024, // 1GB
+			RetryBufferLimit: 1024 * 1024 * 1024, // 1GB
 			GZip:             false,              // Much slower if compressed and not needed
 		},
 	}
@@ -197,24 +197,27 @@ func run(
 	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
 
 	// Timeseries Database
-	var lpClient influxdb2.Client
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		lpClient, err = influx.NewConnectedClientWithOptions(ctx, cfg.TelemetryServer.Url, cfg.TelemetryServer.Token, influx.Options{
-			BatchSize:        cfg.TelemetryServer.BatchSize,
-			FlushInterval:    cfg.TelemetryServer.FlushInterval,
-			RetryBufferLimit: cfg.TelemetryServer.RetryBufferLimit,
-			UseGZip:          cfg.TelemetryServer.GZip,
-		})
-		return err
-	}); err != nil {
-		db.Close()
-		return err
+	influxRdy := true
+	lpClient, err := influx.NewConnectedClientWithOptions(ctx, cfg.TelemetryServer.Url, cfg.TelemetryServer.Token, influx.Options{
+		BatchSize:        cfg.TelemetryServer.BatchSize,
+		FlushInterval:    cfg.TelemetryServer.FlushInterval,
+		RetryBufferLimit: cfg.TelemetryServer.RetryBufferLimit,
+		UseGZip:          cfg.TelemetryServer.GZip,
+	})
+	if err != nil {
+		influxRdy = false
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			log.Warn().Err(err).Str("buffer size (GB)", fmt.Sprintf("%.2f", float64(cfg.TelemetryServer.RetryBufferLimit)/1_073_741_824)).Msg("cannot connect to telemetry db, telemetry will be capture and rotated in buffer until connected")
+		} else {
+			return err
+		}
 	}
-	if err := influx.CreateOrgAndBucket(ctx, lpClient, cfg.TelemetryServer.Org, cfg.TelemetryServer.Bucket); err != nil {
-		return err
+	if influxRdy {
+		if err := influx.CreateOrgAndBucket(ctx, lpClient, cfg.TelemetryServer.Org, cfg.TelemetryServer.Bucket); err != nil {
+			return err
+		}
+		log.Info().Str("url", cfg.TelemetryServer.Url).Msg("connected to puthost")
 	}
-	log.Info().Str("url", cfg.TelemetryServer.Url).Msg("connected to puthost")
 
 	// Bus
 	m, err := mir.Connect(AppName, cfg.DataBusServer.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)

--- a/cmds/prototlm/main.go
+++ b/cmds/prototlm/main.go
@@ -20,14 +20,12 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/influx"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/prototlm_srv"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -186,15 +184,22 @@ func run(
 
 	// Setup
 	// Database
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.DatabaseServer.Url, cfg.DatabaseServer.Namespace, cfg.DatabaseServer.Database, cfg.DatabaseServer.User, cfg.DatabaseServer.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+	db, err := surreal.Connect(ctx, cfg.DatabaseServer.Url,
+		cfg.DatabaseServer.Namespace,
+		cfg.DatabaseServer.Database,
+		cfg.DatabaseServer.User,
+		cfg.DatabaseServer.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msg("disconnected from database, running in degraded state")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.DatabaseServer.Url).Str("namespace", cfg.DatabaseServer.Namespace).Str("database", cfg.DatabaseServer.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	// Timeseries Database
 	influxRdy := true

--- a/cmds/prototlm/main.go
+++ b/cmds/prototlm/main.go
@@ -67,6 +67,11 @@ type (
 		Password string `cfg:"secret"`
 		Org      string
 		Bucket   string
+
+		BatchSize        uint
+		FlushInterval    uint
+		RetryBufferLimit uint
+		GZip             bool
 	}
 )
 
@@ -91,6 +96,11 @@ var (
 			Org:    "Mir",
 			Bucket: "mir",
 			Token:  "mir-operator-token",
+
+			BatchSize:        1000,               // Number of datapoints
+			FlushInterval:    1000,               // 1sec
+			RetryBufferLimit: 1000 * 1024 * 1024, // 1GB
+			GZip:             false,              // Much slower if compressed and not needed
 		},
 	}
 )
@@ -190,7 +200,12 @@ func run(
 	var lpClient influxdb2.Client
 	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
 		var err error
-		lpClient, err = influx.NewConnectedClient(ctx, cfg.TelemetryServer.Url, cfg.TelemetryServer.Token)
+		lpClient, err = influx.NewConnectedClientWithOptions(ctx, cfg.TelemetryServer.Url, cfg.TelemetryServer.Token, influx.Options{
+			BatchSize:        cfg.TelemetryServer.BatchSize,
+			FlushInterval:    cfg.TelemetryServer.FlushInterval,
+			RetryBufferLimit: cfg.TelemetryServer.RetryBufferLimit,
+			UseGZip:          cfg.TelemetryServer.GZip,
+		})
 		return err
 	}); err != nil {
 		db.Close()

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/nats-io/nats.go v1.31.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.31.0
-	github.com/surrealdb/surrealdb.go v0.3.3
+	github.com/surrealdb/surrealdb.go v0.6.0
 	golang.org/x/net v0.38.0
 	google.golang.org/protobuf v1.36.6
 )

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/surrealdb/surrealdb.go v0.3.3 h1:DZg2ij+6b7yiOkc7cfS57UmLAmT8IMtpxcnpXfJNZL0=
-github.com/surrealdb/surrealdb.go v0.3.3/go.mod h1:A0zahuChOaJtvTm2lefQnV+6aJtgqNLm9TIdYhZbw1Q=
+github.com/surrealdb/surrealdb.go v0.6.0 h1:UibfY3HphviUxNieP/0MJj/J3sOtpBM3xzDB3Jv0TBU=
+github.com/surrealdb/surrealdb.go v0.6.0/go.mod h1:A0zahuChOaJtvTm2lefQnV+6aJtgqNLm9TIdYhZbw1Q=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/infra/local_support/compose.yaml
+++ b/infra/local_support/compose.yaml
@@ -1,5 +1,5 @@
 include:
   - ../natsio/compose.yaml
   - ../promstack/compose.yaml
-  - ../influxdb/compose.yaml
+  #- ../influxdb/compose.yaml
   - ../surrealdb/compose.yaml

--- a/infra/local_support/compose.yaml
+++ b/infra/local_support/compose.yaml
@@ -1,5 +1,5 @@
 include:
   - ../natsio/compose.yaml
   - ../promstack/compose.yaml
-  #- ../influxdb/compose.yaml
+  - ../influxdb/compose.yaml
   - ../surrealdb/compose.yaml

--- a/internal/externals/mng/abstract.go
+++ b/internal/externals/mng/abstract.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"regexp"
 
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/pkgs/mir_v1"
-	"github.com/surrealdb/surrealdb.go"
 )
 
 var (
@@ -34,10 +34,10 @@ type MirStore interface {
 }
 
 type surrealMirStore struct {
-	db *surrealdb.DB
+	db *surreal.AutoReconnDB
 }
 
-func NewSurrealMirStore(db *surrealdb.DB) *surrealMirStore {
+func NewSurrealMirStore(db *surreal.AutoReconnDB) *surrealMirStore {
 	return &surrealMirStore{
 		db: db,
 	}

--- a/internal/externals/mng/devices.go
+++ b/internal/externals/mng/devices.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/pkg/errors"
-	"github.com/surrealdb/surrealdb.go"
 )
 
 var (
@@ -30,7 +30,7 @@ type deviceWithId struct {
 
 func (s *surrealMirStore) ListDevice(t mir_v1.DeviceTarget, includeEvents bool) ([]mir_v1.Device, error) {
 	q, v := createListQueryForDevice(t, includeEvents)
-	devs, err := executeQueryForType[[]mir_v1.Device](s.db, q, v)
+	devs, err := surreal.Query[[]mir_v1.Device](s.db, q, v)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrorListingDevices.Error())
 	}
@@ -51,7 +51,7 @@ func (s *surrealMirStore) CreateDevice(d mir_v1.Device) (mir_v1.Device, error) {
 	// Device status is readonly and set by the system
 	d.Status = mir_v1.DeviceStatus{}
 	q, v := createIsDeviceUniqueQuery(d.Meta.Name, d.Meta.Namespace, d.Spec.DeviceId)
-	respCheck, err := executeQueryForType[[]mir_v1.Device](s.db, q, v)
+	respCheck, err := surreal.Query[[]mir_v1.Device](s.db, q, v)
 	if err != nil {
 		return mir_v1.Device{}, fmt.Errorf("%w for device %s/%s: %w", mir_v1.ErrorDbExecutingQuery, d.Meta.Name, d.Meta.Namespace, err)
 	}
@@ -60,7 +60,7 @@ func (s *surrealMirStore) CreateDevice(d mir_v1.Device) (mir_v1.Device, error) {
 	}
 
 	// Create
-	respDb, err := surrealdb.Create[mir_v1.Device](s.db, surrealDeviceTable, d)
+	respDb, err := surreal.Create[mir_v1.Device](s.db, surrealDeviceTable, d)
 	if err != nil {
 		return mir_v1.Device{}, fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 	}
@@ -89,7 +89,7 @@ func (s *surrealMirStore) UpdateDevice(t mir_v1.DeviceTarget, d mir_v1.Device) (
 	if q == "" {
 		return s.ListDevice(t, false)
 	}
-	respDb, err := executeQueryForType[[]mir_v1.Device](s.db, q, v)
+	respDb, err := surreal.Query[[]mir_v1.Device](s.db, q, v)
 	if err != nil {
 		return nil, errors.Wrap(err, mir_v1.ErrorDbExecutingQuery.Error())
 	}
@@ -126,7 +126,7 @@ func (s *surrealMirStore) MergeDevice(t mir_v1.DeviceTarget, patch json.RawMessa
 		}
 		sql := qSb.String()
 
-		respDb, err := executeQueryForType[[]mir_v1.Device](s.db, sql, map[string]any{})
+		respDb, err := surreal.Query[[]mir_v1.Device](s.db, sql, map[string]any{})
 		if err != nil {
 			return nil, errors.Wrap(err, mir_v1.ErrorDbExecutingQuery.Error())
 		}
@@ -141,13 +141,13 @@ func (s *surrealMirStore) DeleteDevice(t mir_v1.DeviceTarget) ([]mir_v1.Device, 
 	}
 
 	qList, vList := createListQueryForDevice(t, false)
-	respDbList, err := executeQueryForType[[]mir_v1.Device](s.db, qList, vList)
+	respDbList, err := surreal.Query[[]mir_v1.Device](s.db, qList, vList)
 	if err != nil {
 		return nil, mir_v1.ErrorDbExecutingQuery
 	}
 
 	q, v := createDeleteQueryForDevice(t)
-	_, err = executeQueryForType[[]mir_v1.Device](s.db, q, v)
+	_, err = surreal.Query[[]mir_v1.Device](s.db, q, v)
 	if err != nil {
 		return nil, mir_v1.ErrorDbExecutingQuery
 	}
@@ -176,7 +176,7 @@ func (s *surrealMirStore) validateDeviceUniqueness(targets mir_v1.DeviceTarget, 
 			} else if len(changingDevs) == 1 {
 				// Check if deviceId is unique
 				q, v := createIsDeviceUniqueQuery("", "", deviceId)
-				respCheck, err := executeQueryForType[[]mir_v1.Device](s.db, q, v)
+				respCheck, err := surreal.Query[[]mir_v1.Device](s.db, q, v)
 				if err != nil {
 					return fmt.Errorf("device unique check: %w: %w", mir_v1.ErrorDbExecutingQuery, err)
 				}
@@ -191,7 +191,7 @@ func (s *surrealMirStore) validateDeviceUniqueness(targets mir_v1.DeviceTarget, 
 			} else if len(changingDevs) == 1 {
 				// Check if name/ns is unique
 				q, v := createIsDeviceUniqueQuery(name, ns, "")
-				respCheck, err := executeQueryForType[[]mir_v1.Device](s.db, q, v)
+				respCheck, err := surreal.Query[[]mir_v1.Device](s.db, q, v)
 				if err != nil {
 					return fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 				}

--- a/internal/externals/mng/devices.go
+++ b/internal/externals/mng/devices.go
@@ -280,7 +280,7 @@ func createListQueryForDevice(t mir_v1.DeviceTarget, includeEvents bool) (sql st
 	if includeEvents {
 		q.WriteString("SELECT *, ")
 		q.WriteString("(")
-		q.WriteString("SELECT spec.type as type, spec.message as message, spec.reason as reason, status.firstAt as firstAt FROM events")
+		q.WriteString("SELECT spec.type as type, spec.message ?? '' as message, spec.reason as reason, status.firstAt ?? NULL as firstAt FROM events")
 		q.WriteString(" WHERE $parent.meta.name = spec.relatedObject.meta.name AND $parent.meta.namespace = spec.relatedObject.meta.namespace ORDER firstAt DESC LIMIT 5")
 		q.WriteString(") as status.events")
 		q.WriteString(" FROM devices")

--- a/internal/externals/mng/events.go
+++ b/internal/externals/mng/events.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/pkg/errors"
-	"github.com/surrealdb/surrealdb.go"
 )
 
 var (
@@ -28,7 +28,7 @@ type eventWithId struct {
 
 func (s *surrealMirStore) ListEvent(t mir_v1.EventTarget) ([]mir_v1.Event, error) {
 	q, v := createListQueryForEvents(t)
-	devs, err := executeQueryForType[[]mir_v1.Event](s.db, q, v)
+	devs, err := surreal.Query[[]mir_v1.Event](s.db, q, v)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrorListingDevices.Error())
 	}
@@ -41,7 +41,7 @@ func (s *surrealMirStore) CreateEvent(e mir_v1.Event) (mir_v1.Event, error) {
 		return mir_v1.Event{}, err
 	}
 	q, v := createIsObjectUniqueQuery(surrealEventTable, e.Meta.Name, e.Meta.Namespace)
-	respCheck, err := executeQueryForType[[]mir_v1.Event](s.db, q, v)
+	respCheck, err := surreal.Query[[]mir_v1.Event](s.db, q, v)
 	if err != nil {
 		return mir_v1.Event{}, fmt.Errorf("%w for event %s/%s: %w", mir_v1.ErrorDbExecutingQuery, e.Meta.Name, e.Meta.Namespace, err)
 	}
@@ -50,7 +50,7 @@ func (s *surrealMirStore) CreateEvent(e mir_v1.Event) (mir_v1.Event, error) {
 	}
 
 	// Create
-	respDb, err := surrealdb.Create[mir_v1.Event](s.db, surrealEventTable, e)
+	respDb, err := surreal.Create[mir_v1.Event](s.db, surrealEventTable, e)
 	if err != nil {
 		return mir_v1.Event{}, fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 	}
@@ -91,7 +91,7 @@ func (s *surrealMirStore) UpdateEvent(t mir_v1.ObjectTarget, upd mir_v1.EventUpd
 	if q == "" {
 		return s.ListEvent(mir_v1.EventTarget{ObjectTarget: t})
 	}
-	respDb, err := executeQueryForType[[]mir_v1.Event](s.db, q, v)
+	respDb, err := surreal.Query[[]mir_v1.Event](s.db, q, v)
 	if err != nil {
 		return nil, errors.Wrap(err, mir_v1.ErrorDbExecutingQuery.Error())
 	}
@@ -128,7 +128,7 @@ func (s *surrealMirStore) MergeEvent(t mir_v1.ObjectTarget, patch json.RawMessag
 		}
 		sql := qSb.String()
 
-		respDb, err := executeQueryForType[[]mir_v1.Event](s.db, sql, map[string]any{})
+		respDb, err := surreal.Query[[]mir_v1.Event](s.db, sql, map[string]any{})
 		if err != nil {
 			return nil, errors.Wrap(err, mir_v1.ErrorDbExecutingQuery.Error())
 		}
@@ -143,13 +143,13 @@ func (s *surrealMirStore) DeleteEvent(t mir_v1.EventTarget) ([]mir_v1.Event, err
 	}
 
 	qList, vList := createListQueryForEvents(t)
-	respDbList, err := executeQueryForType[[]mir_v1.Event](s.db, qList, vList)
+	respDbList, err := surreal.Query[[]mir_v1.Event](s.db, qList, vList)
 	if err != nil {
 		return nil, mir_v1.ErrorDbExecutingQuery
 	}
 
 	q, v := createDeleteQueryForEvents(t)
-	_, err = executeQueryForType[[]mir_v1.Event](s.db, q, v)
+	_, err = surreal.Query[[]mir_v1.Event](s.db, q, v)
 	if err != nil {
 		return nil, mir_v1.ErrorDbExecutingQuery
 	}

--- a/internal/externals/mng/object.go
+++ b/internal/externals/mng/object.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/pkgs/mir_v1"
-	"github.com/surrealdb/surrealdb.go"
 )
 
 func createIsObjectUniqueQuery(table, name, ns string) (sql string, vars map[string]any) {
@@ -20,21 +20,6 @@ func createIsObjectUniqueQuery(table, name, ns string) (sql string, vars map[str
 	q.WriteString(";")
 	sql = q.String()
 	return
-}
-
-func executeQueryForType[T any](db *surrealdb.DB, query string, vars map[string]any) (T, error) {
-	var empty T
-	result, err := surrealdb.Query[T](db, query, vars)
-	if err != nil {
-		return empty, err
-	}
-
-	res := *result
-	if len(res) == 0 {
-		return empty, nil
-	}
-
-	return res[0].Result, nil
 }
 
 func createListQueryForObjects(table string, t mir_v1.ObjectTarget) (sql string, vars map[string]any) {
@@ -94,12 +79,12 @@ func createDeleteQueryForObjects(table string, t mir_v1.ObjectTarget) (sql strin
 	return
 }
 
-func validateObjectMetaForUpdate(db *surrealdb.DB, table string, t mir_v1.ObjectTarget, obj mir_v1.Object) error {
+func validateObjectMetaForUpdate(db *surreal.AutoReconnDB, table string, t mir_v1.ObjectTarget, obj mir_v1.Object) error {
 	// if err := obj.Validate(); err != nil {
 	// 	return err
 	// }
 	q, v := createListQueryForObjects(table, t)
-	changingObjs, err := executeQueryForType[[]mir_v1.Object](db, q, v)
+	changingObjs, err := surreal.Query[[]mir_v1.Object](db, q, v)
 	if err != nil {
 		return fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 	}
@@ -110,7 +95,7 @@ func validateObjectMetaForUpdate(db *surrealdb.DB, table string, t mir_v1.Object
 		} else if len(changingObjs) == 1 {
 			// Check if name/ns is unique
 			q, v := createIsObjectUniqueQuery(table, obj.Meta.Name, obj.Meta.Namespace)
-			respCheck, err := executeQueryForType[[]mir_v1.Object](db, q, v)
+			respCheck, err := surreal.Query[[]mir_v1.Object](db, q, v)
 			if err != nil {
 				return fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 			}
@@ -122,7 +107,7 @@ func validateObjectMetaForUpdate(db *surrealdb.DB, table string, t mir_v1.Object
 		q, v := createListQueryForObjects(table, mir_v1.ObjectTarget{
 			Namespaces: []string{obj.Meta.Namespace},
 		})
-		currentObjs, err := executeQueryForType[[]mir_v1.Object](db, q, v)
+		currentObjs, err := surreal.Query[[]mir_v1.Object](db, q, v)
 		if err != nil {
 			return fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 		}
@@ -147,7 +132,7 @@ func validateObjectMetaForUpdate(db *surrealdb.DB, table string, t mir_v1.Object
 		q, v := createListQueryForObjects(table, mir_v1.ObjectTarget{
 			Names: []string{obj.Meta.Name},
 		})
-		currentObjs, err := executeQueryForType[[]mir_v1.Object](db, q, v)
+		currentObjs, err := surreal.Query[[]mir_v1.Object](db, q, v)
 		if err != nil {
 			return fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 		}

--- a/internal/externals/mng/store_integration_test.go
+++ b/internal/externals/mng/store_integration_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/jsonyaml"
 	"github.com/maxthom/mir/internal/libs/test_utils"
 	"github.com/maxthom/mir/pkgs/mir_v1"
-	"github.com/surrealdb/surrealdb.go"
 	surrealdbModels "github.com/surrealdb/surrealdb.go/pkg/models"
 	"gotest.tools/assert"
 )
 
 var log = test_utils.TestLogger("mirstore")
-var db *surrealdb.DB
+var db *surreal.AutoReconnDB
 var mirStore *surrealMirStore
 
 func TestMain(m *testing.M) {

--- a/internal/externals/mng/store_integration_test.go
+++ b/internal/externals/mng/store_integration_test.go
@@ -2350,25 +2350,19 @@ func TestPublishEventStoreUpdateStatusRequest(t *testing.T) {
 	assert.Equal(t, uResp[0].Status.FirstAt.UTC(), upd.Status.FirstAt.UTC())
 }
 
-func TestPbulishListDeviceWithEvents(t *testing.T) {
+func TestPulishListDeviceWithEvents(t *testing.T) {
 	// Arrange
 	tar := mir_v1.DeviceTarget{
 		Ids: []string{"peanut_butter"},
 	}
-	dev := mir_v1.Device{
-		Object: mir_v1.Object{
-			Meta: mir_v1.Meta{
-				Name:      "peanut_butter",
-				Namespace: "eventstore_testing",
-				Labels: map[string]string{
-					"mirstore": "testing",
-				},
-			},
+	dev := mir_v1.NewDevice().WithMeta(mir_v1.Meta{
+		Name:      "peanut_butter",
+		Namespace: "eventstore_testing",
+		Labels: map[string]string{
+			"mirstore": "testing",
 		},
-		Spec: mir_v1.DeviceSpec{
-			DeviceId: "peanut_butter",
-		},
-	}
+	}).WithId("peanut_butter")
+
 	m := mir_v1.NewEvent().WithMeta(mir_v1.Meta{
 		Name:      "list_dev_with_event_1",
 		Namespace: "eventstore_testing",

--- a/internal/externals/ts/tlm.go
+++ b/internal/externals/ts/tlm.go
@@ -7,6 +7,7 @@ import (
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
+	"github.com/maxthom/mir/internal/libs/external/influx"
 )
 
 type TelemetryStore interface {
@@ -22,16 +23,23 @@ type influxTelemetryStore struct {
 	client  influxdb2.Client
 	writer  api.WriteAPI
 	querier api.QueryAPI
+	errors  chan error
 }
 
 func NewInfluxTelemetryStore(org, bucket string, client influxdb2.Client) *influxTelemetryStore {
-	return &influxTelemetryStore{
+	s := &influxTelemetryStore{
 		org:     org,
 		bucket:  bucket,
 		client:  client,
 		writer:  client.WriteAPI(org, bucket),
 		querier: client.QueryAPI(org),
+		errors:  make(chan error),
 	}
+
+	// Start monitoring writer errors
+	go s.monitorErrors()
+
+	return s
 }
 
 func (s *influxTelemetryStore) WriteDatapoint(line string) {
@@ -39,7 +47,28 @@ func (s *influxTelemetryStore) WriteDatapoint(line string) {
 }
 
 func (s *influxTelemetryStore) Errors() <-chan error {
-	return s.writer.Errors()
+	return s.errors
+}
+
+func (s *influxTelemetryStore) monitorErrors() {
+	for err := range s.writer.Errors() {
+		if err != nil && strings.Contains(err.Error(), "not found: organization") {
+			if err := influx.CreateOrgAndBucket(context.TODO(), s.client, s.org, s.bucket); err != nil {
+				s.errors <- err
+			} else {
+				s.errors <- fmt.Errorf("influx org '%s' and bucket '%s' not found, creating...", s.org, s.bucket)
+			}
+		} else if err != nil && strings.Contains(err.Error(), "not found: bucket") {
+			if err := influx.CreateOrgAndBucket(context.TODO(), s.client, s.org, s.bucket); err != nil {
+				s.errors <- err
+			} else {
+				s.errors <- fmt.Errorf("influx bucket '%s' not found, creating...", s.bucket)
+			}
+		} else {
+			s.errors <- err
+		}
+	}
+	close(s.errors)
 }
 
 type TagInfo struct {

--- a/internal/libs/external/influx/influx.go
+++ b/internal/libs/external/influx/influx.go
@@ -9,6 +9,22 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/domain"
 )
 
+type Options struct {
+	BatchSize        uint
+	FlushInterval    uint
+	RetryBufferLimit uint
+	UseGZip          bool
+}
+
+func DefaultOptions() Options {
+	return Options{
+		BatchSize:        1000,               // Number of datapoints
+		FlushInterval:    1000,               // 1sec
+		RetryBufferLimit: 1000 * 1024 * 1024, // 1GB
+		UseGZip:          false,
+	}
+}
+
 func NewConnectedClient(ctx context.Context, url string, token string) (influxdb2.Client, error) {
 	lpClient := influxdb2.NewClient(url, token)
 	if b, err := lpClient.Ping(ctx); !b || err != nil {
@@ -17,18 +33,43 @@ func NewConnectedClient(ctx context.Context, url string, token string) (influxdb
 	return lpClient, nil
 }
 
+// NewConnectedClientWithOptions creates a new InfluxDB client with enhanced configuration
+// for better retry policies and larger buffer sizes
+func NewConnectedClientWithOptions(ctx context.Context, url string, token string, opts Options) (influxdb2.Client, error) {
+	// Create client with custom options
+	lpClient := influxdb2.NewClientWithOptions(url, token,
+		influxdb2.DefaultOptions().
+			SetBatchSize(opts.BatchSize).               // Default 1000
+			SetFlushInterval(opts.FlushInterval).       // Flush every 1 seconds (default is 1s)
+			SetRetryBufferLimit(opts.RetryBufferLimit). // 10GB retry buffer, default 50MB
+			SetUseGZip(opts.UseGZip).                   // Enable gzip compression
+			SetMaxRetries(100000).                      // More retries
+			SetMaxRetryTime(60*60*24*7*1000).           // Max 7 days of total retry time
+			SetRetryInterval(5000).                     // 5 second base retry interval
+			SetMaxRetryInterval(30*1000).               // Max 30 seconds retry interval
+			SetExponentialBase(2).                      // Exponential backoff
+			SetHTTPRequestTimeout(60))                  // 60 second timeout (default is 20s)
+
+	// Test connection
+	if b, err := lpClient.Ping(ctx); !b || err != nil {
+		return lpClient, err
+	}
+
+	return lpClient, nil
+}
+
 func CreateOrgAndBucket(ctx context.Context, lpClient influxdb2.Client, orgName, bucketName string) error {
 	orgApi := lpClient.OrganizationsAPI()
 	org, err := orgApi.FindOrganizationByName(ctx, orgName)
 	if err != nil {
-		// TODO check if we can create org
 		if strings.Contains(err.Error(), fmt.Sprintf("not found: organization name \"%s\" not found", orgName)) {
 			org, err = orgApi.CreateOrganizationWithName(ctx, orgName)
 			if err != nil {
 				return err
 			}
+		} else {
+			return err
 		}
-		return err
 	}
 
 	_, err = lpClient.BucketsAPI().CreateBucketWithName(ctx, org, bucketName, domain.RetentionRule{

--- a/internal/libs/external/surreal/surreal.go
+++ b/internal/libs/external/surreal/surreal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maxthom/mir/internal/libs/resync"
@@ -23,7 +24,7 @@ const (
 	// Connection is attempting to reconnect
 	StatusReconnecting
 	// Connection cannot authentified itself to the db
-	StatusNotAuthentified
+	StatusNotAuthenticated
 	// Connection is purposfully closed
 	StatusClosed
 )
@@ -34,8 +35,8 @@ func (s ConnectionStatus) String() string {
 		return "Disconnected"
 	case StatusConnected:
 		return "Connected"
-	case StatusNotAuthentified:
-		return "NotAuthentified"
+	case StatusNotAuthenticated:
+		return "NotAuthenticated"
 	case StatusClosed:
 		return "Closed"
 	default:
@@ -45,6 +46,7 @@ func (s ConnectionStatus) String() string {
 
 type AutoReconnDB struct {
 	*surrealdb.DB
+	dbMu        sync.RWMutex
 	ctx         context.Context
 	log         zerolog.Logger
 	ConnStatus  ConnectionStatus
@@ -100,7 +102,7 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 		d := &AutoReconnDB{
 			DB:          db,
 			ctx:         ctx,
-			ConnStatus:  StatusNotAuthentified,
+			ConnStatus:  StatusNotAuthenticated,
 			connHandler: h,
 			Url:         url,
 			User:        user,
@@ -141,6 +143,8 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 }
 
 func (db *AutoReconnDB) Close() error {
+	db.dbMu.RLock()
+	defer db.dbMu.RUnlock()
 	if db.DB == nil {
 		return nil
 	}
@@ -169,10 +173,13 @@ func (db *AutoReconnDB) monitorAndReconnect() {
 			for {
 				select {
 				case <-db.ctx.Done():
+					return
 				case <-ticker.C:
 					d, err := connect(db.ctx, db.Url, db.Namespace, db.Database, db.User, db.Password, db.connHandler)
+					db.dbMu.Lock()
 					db.DB = d.DB
 					db.ConnStatus = d.ConnStatus
+					db.dbMu.Unlock()
 					if err != nil {
 						// Mean still trying to connect
 						if db.connHandler.FnFailedReconnect != nil {
@@ -199,7 +206,9 @@ func Create[T any, TWhat surrealdb.TableOrRecord](db *AutoReconnDB, what TWhat, 
 	}
 	ctxT, cancel := context.WithTimeout(db.ctx, 5*time.Second)
 	defer cancel()
+	db.dbMu.RLock()
 	respDb, err := surrealdb.Create[T](ctxT, db.DB, what, data)
+	db.dbMu.RUnlock()
 	if err != nil {
 		// Check for connection errors
 		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "context deadline exceeded") {
@@ -219,7 +228,9 @@ func Query[T any](db *AutoReconnDB, query string, vars map[string]any) (T, error
 
 	ctxT, cancel := context.WithTimeout(db.ctx, 5*time.Second)
 	defer cancel()
+	db.dbMu.RLock()
 	result, err := surrealdb.Query[T](ctxT, db.DB, query, vars)
+	db.dbMu.RUnlock()
 	if err != nil {
 		// Check for connection errors
 		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "context deadline exceeded") {

--- a/internal/libs/external/surreal/surreal.go
+++ b/internal/libs/external/surreal/surreal.go
@@ -1,34 +1,237 @@
 package surreal
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/maxthom/mir/internal/libs/resync"
+	"github.com/rs/zerolog"
 	"github.com/surrealdb/surrealdb.go"
 )
 
-func ConnectToDb(url, namespace, database, user, password string) (*surrealdb.DB, error) {
-	db, err := surrealdb.New(url)
+var ErrDatabaseDisconnected = fmt.Errorf("database disconnected")
+
+type ConnectionStatus int
+
+const (
+	// Connection is connected
+	StatusConnected ConnectionStatus = iota
+	// Connection is disconnected and not trying to reconnect
+	StatusDisconnected
+	// Connection is attempting to reconnect
+	StatusReconnecting
+	// Connection cannot authentified itself to the db
+	StatusNotAuthentified
+	// Connection is purposfully closed
+	StatusClosed
+)
+
+func (s ConnectionStatus) String() string {
+	switch s {
+	case StatusDisconnected:
+		return "Disconnected"
+	case StatusConnected:
+		return "Connected"
+	case StatusNotAuthentified:
+		return "NotAuthentified"
+	case StatusClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
+type AutoReconnDB struct {
+	*surrealdb.DB
+	ctx         context.Context
+	log         zerolog.Logger
+	ConnStatus  ConnectionStatus
+	once        resync.Once
+	isConn      bool
+	connHandler ConnHandler
+	Url         string
+	User        string
+	Password    string
+	Namespace   string
+	Database    string
+}
+
+type ConnHandler struct {
+	FnConnected       func(url string)
+	FnFailedReconnect func(url string, nextAttempt time.Duration)
+	FnDisconnected    func(url string)
+}
+
+func Connect(ctx context.Context, url, namespace, database, user, password string, h ConnHandler) (*AutoReconnDB, error) {
+	db, err := connect(ctx, url, namespace, database, user, password, h)
 	if err != nil {
-		return nil, err
+		// Check for connection errors
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "context deadline exceeded") {
+			db.monitorAndReconnect()
+		}
+		return db, err
 	}
-
-	if _, err = db.SignIn(&surrealdb.Auth{
-		Username: user,
-		Password: password,
-	}); err != nil {
-		return nil, err
-	}
-
-	if err = db.Use(namespace, database); err != nil {
-		return nil, err
-	}
-
 	return db, nil
 }
 
-func CreateUpdateQuery(fields map[string]any) error {
-	return nil
+func connect(ctx context.Context, url, namespace, database, user, password string, h ConnHandler) (*AutoReconnDB, error) {
+	db, err := surrealdb.Connect(ctx, url)
+	if err != nil {
+		d := &AutoReconnDB{
+			DB:          db,
+			ctx:         ctx,
+			ConnStatus:  StatusDisconnected,
+			connHandler: h,
+			Url:         url,
+			User:        user,
+			Password:    password,
+			Namespace:   namespace,
+			Database:    database,
+		}
+		return d, err
+	}
+
+	if _, err = db.SignIn(ctx, &surrealdb.Auth{
+		Username: user,
+		Password: password,
+	}); err != nil {
+		d := &AutoReconnDB{
+			DB:          db,
+			ctx:         ctx,
+			ConnStatus:  StatusNotAuthentified,
+			connHandler: h,
+			Url:         url,
+			User:        user,
+			Password:    password,
+			Namespace:   namespace,
+			Database:    database,
+		}
+		return d, err
+	}
+
+	if err = db.Use(ctx, namespace, database); err != nil {
+		return &AutoReconnDB{
+			DB:          db,
+			ctx:         ctx,
+			ConnStatus:  StatusConnected,
+			connHandler: h,
+			isConn:      true,
+			Url:         url,
+			User:        user,
+			Password:    password,
+			Namespace:   namespace,
+			Database:    database,
+		}, err
+	}
+
+	return &AutoReconnDB{
+		DB:          db,
+		ctx:         ctx,
+		ConnStatus:  StatusConnected,
+		connHandler: h,
+		isConn:      true,
+		Url:         url,
+		User:        user,
+		Password:    password,
+		Namespace:   namespace,
+		Database:    database,
+	}, nil
 }
 
-// Create ReadQuery
-func CreateReadQuery(fields []string) error {
-	return nil
+func (db *AutoReconnDB) Close() error {
+	if db.DB == nil {
+		return nil
+	}
+	return db.DB.Close(db.ctx)
+}
+
+// TODO, if error is of network disconnect
+//  - [x] update status
+//  - [x] start monitoring process
+//    - [x] check connection every few seconds
+//    - [x] recreate the db if needed
+//    - [x] set status to connected
+//  - [x] discard coming request as it is disconnected
+//  - [x] add status changes handler
+
+func (db *AutoReconnDB) monitorAndReconnect() {
+	db.isConn = false
+	fnM := func() {
+		go func() {
+			if db.connHandler.FnDisconnected != nil {
+				db.connHandler.FnDisconnected(db.Url)
+			}
+			t := 5 * time.Second
+			ticker := time.NewTicker(t)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-db.ctx.Done():
+				case <-ticker.C:
+					d, err := connect(db.ctx, db.Url, db.Namespace, db.Database, db.User, db.Password, db.connHandler)
+					db.DB = d.DB
+					db.ConnStatus = d.ConnStatus
+					if err != nil {
+						// Mean still trying to connect
+						if db.connHandler.FnFailedReconnect != nil {
+							db.connHandler.FnFailedReconnect(db.Url, t)
+						}
+						continue
+					}
+					db.isConn = true
+					if db.connHandler.FnConnected != nil {
+						db.connHandler.FnConnected(db.Url)
+					}
+					db.once.Reset()
+					return
+				}
+			}
+		}()
+	}
+	db.once.Do(fnM)
+}
+
+func Create[T any, TWhat surrealdb.TableOrRecord](db *AutoReconnDB, what TWhat, data any) (*T, error) {
+	if !db.isConn {
+		return nil, ErrDatabaseDisconnected
+	}
+	ctxT, cancel := context.WithTimeout(db.ctx, 5*time.Second)
+	defer cancel()
+	respDb, err := surrealdb.Create[T](ctxT, db.DB, what, data)
+	if err != nil {
+		// Check for connection errors
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "context deadline exceeded") {
+			db.monitorAndReconnect()
+		}
+		return nil, err
+	}
+
+	return respDb, err
+}
+
+func Query[T any](db *AutoReconnDB, query string, vars map[string]any) (T, error) {
+	var empty T
+	if !db.isConn {
+		return empty, ErrDatabaseDisconnected
+	}
+
+	ctxT, cancel := context.WithTimeout(db.ctx, 5*time.Second)
+	defer cancel()
+	result, err := surrealdb.Query[T](ctxT, db.DB, query, vars)
+	if err != nil {
+		// Check for connection errors
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "context deadline exceeded") {
+			db.monitorAndReconnect()
+		}
+		return empty, err
+	}
+
+	res := *result
+	if len(res) == 0 {
+		return empty, nil
+	}
+
+	return res[0].Result, nil
 }

--- a/internal/libs/external/utils.go
+++ b/internal/libs/external/utils.go
@@ -8,6 +8,37 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// CallWithTimeout executes a function with a timeout and returns the result or an error if it times out
+func CallWithTimeout[T any](ctx context.Context, timeout time.Duration, fn func() (T, error)) (T, error) {
+	var zero T
+	
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	
+	// Result channel
+	type result struct {
+		value T
+		err   error
+	}
+	
+	resultChan := make(chan result, 1)
+	
+	// Execute function in goroutine
+	go func() {
+		value, err := fn()
+		resultChan <- result{value: value, err: err}
+	}()
+	
+	// Wait for result or timeout
+	select {
+	case <-ctx.Done():
+		return zero, fmt.Errorf("operation timed out after %v", timeout)
+	case res := <-resultChan:
+		return res.value, res.err
+	}
+}
+
 func BackOffRetry(ctx context.Context, l zerolog.Logger, maxTime time.Duration, retryFn func() error) error {
 	ctx, cancel := context.WithTimeout(ctx, maxTime)
 	defer cancel()
@@ -18,11 +49,10 @@ func BackOffRetry(ctx context.Context, l zerolog.Logger, maxTime time.Duration, 
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("connection cancelled or timed out: %w", ctx.Err())
+			return fmt.Errorf("context cancelled or timed out: %w", ctx.Err())
 		default:
 		}
 
-		// db, err := ConnectToDb(url, namespace, database, user, password)
 		err := retryFn()
 		if err == nil {
 			return nil

--- a/internal/libs/resync/once.go
+++ b/internal/libs/resync/once.go
@@ -1,0 +1,38 @@
+package resync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Once is an object that will perform exactly one action
+// until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+type Once struct {
+	m    sync.Mutex
+	done uint32
+}
+
+// Do simulates sync.Once.Do by executing the specified function
+// only once, until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+func (o *Once) Do(f func()) {
+	if atomic.LoadUint32(&o.done) == 1 {
+		return
+	}
+	// Slow-path.
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.done == 0 {
+		defer atomic.StoreUint32(&o.done, 1)
+		f()
+	}
+}
+
+// Reset indicates that the next call to Do should actually be called
+// once again.
+func (o *Once) Reset() {
+	o.m.Lock()
+	defer o.m.Unlock()
+	atomic.StoreUint32(&o.done, 0)
+}

--- a/internal/libs/test_utils/test_utils.go
+++ b/internal/libs/test_utils/test_utils.go
@@ -12,11 +12,11 @@ import (
 	"github.com/maxthom/mir/internal/clients/core_client"
 	"github.com/maxthom/mir/internal/libs/external/influx"
 	bus "github.com/maxthom/mir/internal/libs/external/natsio"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog"
 	logger "github.com/rs/zerolog/log"
-	"github.com/surrealdb/surrealdb.go"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -44,7 +44,7 @@ type InfluxInfo struct {
 	Bucket string
 }
 
-func SetupAllExternalsPanic(ctx context.Context, conns ConnsInfo) (*nats.Conn, *surrealdb.DB, influxdb2.Client, api.WriteAPI, api.QueryAPI) {
+func SetupAllExternalsPanic(ctx context.Context, conns ConnsInfo) (*nats.Conn, *surreal.AutoReconnDB, influxdb2.Client, api.WriteAPI, api.QueryAPI) {
 	b := SetupNatsConPanic(conns.BusUrl)
 	s := SetupSurrealDbConnsPanic(conns.Surreal.Url, conns.Surreal.User, conns.Surreal.Pass, conns.Surreal.Ns, conns.Surreal.Db)
 	c, w, q := SetupInfluxConnsPanic(ctx, conns.Influx.Url, conns.Influx.Token, conns.Influx.Org, conns.Influx.Bucket)
@@ -63,23 +63,11 @@ func SetupInfluxConnsPanic(ctx context.Context, url, token, org, bucket string) 
 	return c, w, q
 }
 
-func SetupSurrealDbConnsPanic(url, user, pass, ns, db string) *surrealdb.DB {
-	d, err := surrealdb.New(url)
+func SetupSurrealDbConnsPanic(url, user, pass, ns, db string) *surreal.AutoReconnDB {
+	d, err := surreal.Connect(context.Background(), url, ns, db, user, pass, surreal.ConnHandler{})
 	if err != nil {
 		panic(err)
 	}
-
-	if _, err = d.SignIn(&surrealdb.Auth{
-		Username: user,
-		Password: pass,
-	}); err != nil {
-		panic(err)
-	}
-
-	if err = d.Use(ns, db); err != nil {
-		panic(err)
-	}
-
 	return d
 }
 
@@ -113,19 +101,12 @@ func CreateDevices(bus *nats.Conn, devices []*mir_apiv1.CreateDeviceRequest) ([]
 	return responses, nil
 }
 
-func ExecuteTestQueryForType[T any](t *testing.T, db *surrealdb.DB, query string, vars map[string]any) T {
-	var empty T
-	result, err := surrealdb.Query[T](db, query, vars)
+func ExecuteTestQueryForType[T any](t *testing.T, db *surreal.AutoReconnDB, query string, vars map[string]any) T {
+	result, err := surreal.Query[T](db, query, vars)
 	if err != nil {
 		t.Error(err)
 	}
-
-	res := *result
-	if len(res) == 0 {
-		return empty
-	}
-
-	return res[0].Result
+	return result
 }
 
 func strRef(s string) *string {

--- a/internal/servers/core_srv/server.go
+++ b/internal/servers/core_srv/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
 	bus "github.com/maxthom/mir/internal/libs/external/natsio"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/maxthom/mir/pkgs/module/mir"
@@ -321,7 +323,9 @@ func (s *CoreServer) hearthbeatPulsor(ctx context.Context, interval time.Duratio
 				})
 				devs, err := s.store.UpdateDevice(t, d)
 				if err != nil {
-					l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+					if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+						l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+					}
 					continue
 				}
 				l.Info().Str("route", "hearthbeat_pulsor").Str("event", "device_offline").Strs("new devices", newOffline).Msg("offline devices")
@@ -354,15 +358,6 @@ func (s *CoreServer) hearthbeatSub(msg *mir.Msg, deviceId string) {
 		return &b
 	}
 	// Since this update is only for hearthbeat and often, we dont want to have a device update event
-	// updReq := &mir_apiv1.UpdateDeviceRequest{
-	// 	Targets: &mir_apiv1.DeviceTarget{
-	// 		Ids: []string{deviceId},
-	// 	},
-	// 	Status: &mir_apiv1.UpdateDeviceRequest_Status{
-	// 		Online:         toBoolRef(true),
-	// 		LastHearthbeat: mir_v1.AsProtoTimestamp(timeNow),
-	// 	},
-	// }
 	t := mir_v1.DeviceTarget{
 		Ids: []string{deviceId},
 	}
@@ -373,7 +368,9 @@ func (s *CoreServer) hearthbeatSub(msg *mir.Msg, deviceId string) {
 
 	dev, err := s.store.UpdateDevice(t, d)
 	if err != nil {
-		l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+		if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+		}
 		msg.Ack()
 		return
 	}
@@ -389,7 +386,9 @@ func (s *CoreServer) hearthbeatSub(msg *mir.Msg, deviceId string) {
 		}
 		dev, err = s.store.UpdateDevice(t, d)
 		if err != nil {
-			l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+			if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+				l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
+			}
 			msg.Ack()
 			return
 		}

--- a/internal/servers/core_srv/server_integration_test.go
+++ b/internal/servers/core_srv/server_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/maxthom/mir/internal/clients"
 	"github.com/maxthom/mir/internal/clients/core_client"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/swarm"
 	"github.com/maxthom/mir/internal/libs/test_utils"
 	core_testv1 "github.com/maxthom/mir/internal/servers/core_srv/proto_test/gen/core_test/v1"
@@ -19,7 +20,6 @@ import (
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/nats-io/nats.go"
-	"github.com/surrealdb/surrealdb.go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"gotest.tools/assert"
@@ -27,7 +27,7 @@ import (
 
 var mSdk *mir.Mir
 var busUrl = "nats://127.0.0.1:4222"
-var db *surrealdb.DB
+var db *surreal.AutoReconnDB
 
 func TestMain(m *testing.M) {
 	// Setup

--- a/internal/servers/eventstore_srv/server.go
+++ b/internal/servers/eventstore_srv/server.go
@@ -136,7 +136,6 @@ func (s *EventStoreServer) streamEventsSub(msg *mir.Msg, subjectId string, req m
 		return
 	}
 
-	// TODO name of events, tbd
 	event := mir_v1.NewEvent()
 	id, err := uuid.NewV7()
 	if err != nil {

--- a/internal/servers/protocfg_srv/server.go
+++ b/internal/servers/protocfg_srv/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/maxthom/mir/internal/clients/cfg_client"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/json_template"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
@@ -137,22 +138,39 @@ func (s *ProtoCfgServer) Shutdown() error {
 func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error) {
 	l.Info().Any("req", req).Msg("list config request")
 	requestTotal.WithLabelValues("list").Inc()
+	degradedMode := false
 	// 1. get device list
 	// 2. for each device, get stored schema, if empty, fetch from device
 	// 3. return list of config
 
-	devs, err := s.devStore.ListDevice(mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets), false)
+	t := mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets)
+	devs, err := s.devStore.ListDevice(t, false)
 	if err != nil {
-		l.Error().Err(err).Msg("error occure while listing devices")
-		requestErrorTotal.WithLabelValues("list").Inc()
-		return nil, fmt.Errorf("error listing devices from db: %w", err)
+		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			degradedMode = true
+			if !t.HasOnlyIdsTarget() {
+				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
+			}
+			devs = []mir_v1.Device{}
+			for _, i := range t.Ids {
+				devs = append(devs, mir_v1.NewDevice().WithId(i))
+			}
+		} else {
+			l.Error().Err(err).Msg("error occure while listing devices")
+			requestErrorTotal.WithLabelValues("list").Inc()
+			return nil, fmt.Errorf("error listing devices from db: %w", err)
+		}
 	}
 
 	devsCmds := make(map[string]*mir_apiv1.Configs)
 	for _, dev := range devs {
+		nameNs := dev.GetNameNamespace()
+		if degradedMode {
+			nameNs = dev.Spec.DeviceId
+		}
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
-			devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Configs{
+			devsCmds[nameNs] = &mir_apiv1.Configs{
 				Error: err.Error(),
 			}
 			continue
@@ -160,7 +178,7 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 
 		cfgs, err := reg.GetConfigList(req.FilterLabels)
 		if err != nil {
-			devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Configs{
+			devsCmds[nameNs] = &mir_apiv1.Configs{
 				Error: err.Error(),
 			}
 			continue
@@ -172,13 +190,17 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 				b, err := json.Marshal(v)
 				if err != nil {
 					cfg.Error = err.Error()
-					continue
+				} else {
+					cfg.Values = string(b)
 				}
-				cfg.Values = string(b)
+			} else {
+				if degradedMode {
+					cfg.Values = errors.New("{\"err\": \"can't retrieve config in degraded mode\"}").Error()
+				}
 			}
 			cfgList = append(cfgList, cfg)
 		}
-		devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Configs{
+		devsCmds[nameNs] = &mir_apiv1.Configs{
 			Configs: cfgList,
 		}
 	}

--- a/internal/servers/protocmd_srv/server.go
+++ b/internal/servers/protocmd_srv/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/maxthom/mir/internal/clients/cmd_client"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/json_template"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
@@ -147,9 +148,22 @@ type cmdDevicePayload struct {
 }
 
 func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendCommandRequest) (map[string]*mir_apiv1.SendCommandResponse_CommandResponse, error) {
-	devs, err := s.devStore.ListDevice(mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets), false)
+	degradedMode := false
+	t := mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets)
+	devs, err := s.devStore.ListDevice(t, false)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			degradedMode = true
+			if !t.HasOnlyIdsTarget() {
+				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
+			}
+			devs = []mir_v1.Device{}
+			for _, i := range t.Ids {
+				devs = append(devs, mir_v1.NewDevice().WithId(i))
+			}
+		} else {
+			return nil, err
+		}
 	} else if len(devs) == 0 {
 		return nil, mng.ErrorNoDeviceFound
 	}
@@ -163,11 +177,15 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 	devInError := false
 	if !req.NoValidation || req.PayloadEncoding == mir_apiv1.Encoding_ENCODING_JSON {
 		for _, dev := range devs {
+			nameNs := dev.GetNameNamespace()
+			if degradedMode {
+				nameNs = dev.Spec.DeviceId
+			}
 			// Retrieve descriptor
 			msgReqDesc, _, _, err := s.schStore.GetDeviceSchemaAndDescriptor(dev.Spec.DeviceId, req.Name, req.RefreshSchema)
 			if err != nil {
 				l.Error().Err(err).Str("device_id", dev.Spec.DeviceId).Msg("error retrieving command descriptor from device schema")
-				devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+				devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 					DeviceId: dev.Spec.DeviceId,
 					Status:   mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_ERROR,
 					Error:    errors.Wrap(err, "error retrieve command descriptor from device schema").Error(),
@@ -182,13 +200,13 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 				if err != nil {
 					l.Error().Err(err).Str("device_id", dev.Spec.DeviceId).Msg("error generating command template from device schema")
 					deviceCmdSentErrorTotal.Inc()
-					devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+					devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 						DeviceId: dev.Spec.DeviceId,
 						Status:   mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_ERROR,
 						Error:    errors.Wrap(err, "error generating command template from device schema").Error(),
 					}
 				}
-				devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+				devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 					DeviceId: dev.Spec.DeviceId,
 					Name:     req.Name,
 					Payload:  tpl,
@@ -213,7 +231,7 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 			if err != nil {
 				l.Error().Err(err).Str("device_id", dev.Spec.DeviceId).Msg("error unmarshaling payload")
 				deviceCmdSentErrorTotal.Inc()
-				devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+				devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 					DeviceId: dev.Spec.DeviceId,
 					Status:   mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_ERROR,
 					Error:    errors.Wrap(err, "error unmarshaling payload").Error(),
@@ -223,20 +241,24 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 			}
 
 			// Prepare
-			devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+			devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 				DeviceId: dev.Spec.DeviceId,
 				Status:   mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_VALIDATED,
 			}
-			commandsToSend[dev.GetNameNamespace()] = &cmdDevicePayload{payload: bytePayload, deviceId: dev.Spec.DeviceId}
-			l.Debug().Str("device_id", dev.Spec.DeviceId).Msgf("command %s validated for device %s", req.Name, dev.GetNameNamespace())
+			commandsToSend[nameNs] = &cmdDevicePayload{payload: bytePayload, deviceId: dev.Spec.DeviceId}
+			l.Debug().Str("device_id", dev.Spec.DeviceId).Msgf("command %s validated for device %s", req.Name, nameNs)
 		}
 	} else {
 		for _, dev := range devs {
-			devResp[dev.GetNameNamespace()] = &mir_apiv1.SendCommandResponse_CommandResponse{
+			nameNs := dev.GetNameNamespace()
+			if degradedMode {
+				nameNs = dev.Spec.DeviceId
+			}
+			devResp[nameNs] = &mir_apiv1.SendCommandResponse_CommandResponse{
 				DeviceId: dev.Spec.DeviceId,
 				Status:   mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_PENDING,
 			}
-			commandsToSend[dev.GetNameNamespace()] = &cmdDevicePayload{payload: req.Payload, deviceId: dev.Spec.DeviceId}
+			commandsToSend[nameNs] = &cmdDevicePayload{payload: req.Payload, deviceId: dev.Spec.DeviceId}
 		}
 	}
 
@@ -340,11 +362,13 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 	wg.Wait()
 
 	// Event
-	if len(commandsToSend) > 0 {
-		for nameNs, cmdResp := range devResp {
-			nns := strings.Split(nameNs, "/")
-			if err = publishCommandEvent(s.m, msg, nns[0], nns[1], cmdResp); err != nil {
-				l.Warn().Err(err).Msg("error while publishing device command event")
+	if !degradedMode {
+		if len(commandsToSend) > 0 {
+			for nameNs, cmdResp := range devResp {
+				nns := strings.Split(nameNs, "/")
+				if err = publishCommandEvent(s.m, msg, nns[0], nns[1], cmdResp); err != nil {
+					l.Warn().Err(err).Msg("error while publishing device command event")
+				}
 			}
 		}
 	}
@@ -355,22 +379,39 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error) {
 	l.Info().Any("req", req).Msg("list command request")
 	requestTotal.WithLabelValues("list").Inc()
+	degradedMode := false
 	// 1. get device list
 	// 2. for each device, get stored schema, if empty, fetch from device
 	// 3. return list of commands
 
-	devs, err := s.devStore.ListDevice(mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets), false)
+	t := mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets)
+	devs, err := s.devStore.ListDevice(t, false)
 	if err != nil {
-		l.Error().Err(err).Msg("error occure while listing devices")
-		requestErrorTotal.WithLabelValues("list").Inc()
-		return nil, fmt.Errorf("error listing devices from db: %w", err)
+		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			degradedMode = true
+			if !t.HasOnlyIdsTarget() {
+				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
+			}
+			devs = []mir_v1.Device{}
+			for _, i := range t.Ids {
+				devs = append(devs, mir_v1.NewDevice().WithId(i))
+			}
+		} else {
+			l.Error().Err(err).Msg("error occure while listing devices")
+			requestErrorTotal.WithLabelValues("list").Inc()
+			return nil, fmt.Errorf("error listing devices from db: %w", err)
+		}
 	}
 
 	devsCmds := make(map[string]*mir_apiv1.Commands)
 	for _, dev := range devs {
+		nameNs := dev.GetNameNamespace()
+		if degradedMode {
+			nameNs = dev.Spec.DeviceId
+		}
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
-			devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Commands{
+			devsCmds[nameNs] = &mir_apiv1.Commands{
 				Error: err.Error(),
 			}
 			continue
@@ -378,7 +419,7 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 
 		cmds, err := reg.GetCommandsList(req.FilterLabels)
 		if err != nil {
-			devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Commands{
+			devsCmds[nameNs] = &mir_apiv1.Commands{
 				Error: err.Error(),
 			}
 			continue
@@ -388,7 +429,7 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 		for _, cmd := range cmds {
 			cmdsList = append(cmdsList, cmd)
 		}
-		devsCmds[dev.GetNameNamespace()] = &mir_apiv1.Commands{
+		devsCmds[nameNs] = &mir_apiv1.Commands{
 			Commands: cmdsList,
 		}
 	}

--- a/internal/servers/prototlm_srv/server.go
+++ b/internal/servers/prototlm_srv/server.go
@@ -3,11 +3,13 @@ package prototlm_srv
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/externals/ts"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	proto_lineprotocol "github.com/maxthom/mir/internal/libs/proto/line_protocol"
 	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/internal/services/schema_cache"
@@ -217,29 +219,46 @@ type schemaPerDevices struct {
 func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId string, req *mir_apiv1.SendListTelemetryRequest) ([]*mir_apiv1.DevicesTelemetry, error) {
 	l.Info().Any("req", req).Msg("list telemetry request")
 	requestTotal.WithLabelValues("list").Inc()
+	degradedMode := false
 
-	devs, err := s.devStore.ListDevice(mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets), false)
+	t := mir_v1.ProtoDeviceTargetToMirDeviceTarget(req.Targets)
+	devs, err := s.devStore.ListDevice(t, false)
 	if err != nil {
-		requestErrorTotal.WithLabelValues("list").Inc()
-		l.Error().Err(err).Msg("error occure while listing devices")
-		return nil, fmt.Errorf("error listing device from db: %w", err)
+		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			degradedMode = true
+			if !t.HasOnlyIdsTarget() {
+				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
+			}
+			devs = []mir_v1.Device{}
+			for _, i := range t.Ids {
+				devs = append(devs, mir_v1.NewDevice().WithId(i))
+			}
+		} else {
+			requestErrorTotal.WithLabelValues("list").Inc()
+			l.Error().Err(err).Msg("error occure while listing devices")
+			return nil, fmt.Errorf("error listing device from db: %w", err)
+		}
 	}
 
 	devsTlm := []*mir_apiv1.DevicesTelemetry{}
 	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
+		nameNs := dev.GetNameNamespace()
+		if degradedMode {
+			nameNs = dev.Spec.DeviceId
+		}
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
 			found := false
 			for _, d := range devsTlm {
 				if d.Error == err.Error() {
-					d.DevicesNamens = append(d.DevicesNamens, dev.GetNameNamespace())
+					d.DevicesNamens = append(d.DevicesNamens, nameNs)
 					found = true
 				}
 			}
 			if !found {
 				devsTlm = append(devsTlm, &mir_apiv1.DevicesTelemetry{
-					DevicesNamens: []string{dev.GetNameNamespace()},
+					DevicesNamens: []string{nameNs},
 					Error:         err.Error(),
 				})
 			}
@@ -249,7 +268,7 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 		for _, sch := range devSchemas {
 			if mir_proto.AreSchemaEqual(sch.sch, reg) {
 				sch.devsId = append(sch.devsId, dev.Spec.DeviceId)
-				sch.devsNameNs = append(sch.devsNameNs, dev.GetNameNamespace())
+				sch.devsNameNs = append(sch.devsNameNs, nameNs)
 				found = true
 			}
 
@@ -258,7 +277,7 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 			devSchemas = append(devSchemas, &schemaPerDevices{
 				sch:        reg,
 				devsId:     []string{dev.Spec.DeviceId},
-				devsNameNs: []string{dev.GetNameNamespace()},
+				devsNameNs: []string{nameNs},
 			})
 		}
 	}

--- a/internal/services/schema_cache/proto_cache.go
+++ b/internal/services/schema_cache/proto_cache.go
@@ -164,7 +164,7 @@ func (c *MirSchemaCache) reconcileDeviceSchema(deviceId string, forceDeviceFetch
 		}
 		if len(devs) == 0 {
 			// If error, we fetch from device
-			if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			if err != nil && !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 				return mir_v1.Device{}, nil, fmt.Errorf("device %s not found", deviceId)
 			}
 		}

--- a/internal/services/schema_cache/proto_cache.go
+++ b/internal/services/schema_cache/proto_cache.go
@@ -2,6 +2,7 @@ package schema_cache
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/maxthom/mir/pkgs/module/mir"
@@ -155,10 +157,16 @@ func (c *MirSchemaCache) reconcileDeviceSchema(deviceId string, forceDeviceFetch
 				Ids: []string{deviceId},
 			}, false)
 		if err != nil {
-			return mir_v1.Device{}, nil, fmt.Errorf("error listing devices: %s", err)
+			// If error, we fetch from device
+			if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+				return mir_v1.Device{}, nil, fmt.Errorf("error listing devices: %s", err)
+			}
 		}
 		if len(devs) == 0 {
-			return mir_v1.Device{}, nil, fmt.Errorf("device %s not found", deviceId)
+			// If error, we fetch from device
+			if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+				return mir_v1.Device{}, nil, fmt.Errorf("device %s not found", deviceId)
+			}
 		}
 		if len(devs) > 0 {
 			if len(devs[0].Status.Schema.CompressedSchema) != 0 {
@@ -197,6 +205,11 @@ func (c *MirSchemaCache) reconcileDeviceSchema(deviceId string, forceDeviceFetch
 		}),
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
+			schemaReconcileTotal.WithLabelValues("device").Inc()
+			l.Info().Str("device_id", deviceId).Msgf("reconciled schema for %s from device", deviceId)
+			return mir_v1.NewDevice().WithId(deviceId), sch, nil
+		}
 		return mir_v1.Device{}, nil, fmt.Errorf("error updating device: %w", err)
 	}
 	if len(devResp) == 0 {

--- a/internal/ui/cli/command_cmd.go
+++ b/internal/ui/cli/command_cmd.go
@@ -68,7 +68,7 @@ func (d *CommandListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg Config) error {
 	}
 	resp, err := m.Server().ListCommands().Request(req)
 	if err != nil {
-		return fmt.Errorf("error publising list command request: %w", err)
+		return err
 	}
 
 	tpls := map[string][]string{}
@@ -127,6 +127,7 @@ func (d *CommandSendCmd) Validate() error {
 	}
 
 	if d.NameNs != "" {
+		fmt.Println(d.NameNs)
 		d.Target = getTargetFromNameNs(d.NameNs)
 	}
 

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
 	"github.com/maxthom/mir/internal/libs/build_meta"
-	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/influx"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/servers/core_srv"
@@ -29,7 +28,6 @@ import (
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	"github.com/maxthom/mir/pkgs/module/mir"
 	"github.com/rs/zerolog"
-	"github.com/surrealdb/surrealdb.go"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"gopkg.in/yaml.v3"
@@ -160,15 +158,24 @@ func (d *ServeCmd) run(
 	ctx, cancel := mir_signals.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGINT)
 
 	// Setup
-	var db *surrealdb.DB
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		db, err = surreal.ConnectToDb(cfg.Surreal.Url, cfg.Surreal.Namespace, cfg.Surreal.Database, cfg.Surreal.User, cfg.Surreal.Password)
-		return err
-	}); err != nil {
-		return err
-	}
-	log.Info().Str("url", cfg.Surreal.Url).Str("namespace", cfg.Surreal.Namespace).Str("database", cfg.Surreal.Database).Msg("connected to database")
+	var db *surreal.AutoReconnDB
+	var err error
+	db, err = surreal.Connect(ctx, cfg.Surreal.Url,
+		cfg.Surreal.Namespace,
+		cfg.Surreal.Database,
+		cfg.Surreal.User,
+		cfg.Surreal.Password,
+		surreal.ConnHandler{
+			FnConnected: func(url string) {
+				log.Info().Str("url", cfg.Surreal.Url).Str("namespace", cfg.Surreal.Namespace).Str("database", cfg.Surreal.Database).Msg("connected to database")
+			},
+			FnDisconnected: func(url string) {
+				log.Error().Str("url", cfg.Surreal.Url).Str("namespace", cfg.Surreal.Namespace).Str("database", cfg.Surreal.Database).Msg("disconnected from database")
+			},
+			FnFailedReconnect: func(url string, nextAttempt time.Duration) {
+				log.Warn().Str("url", cfg.Surreal.Url).Str("namespace", cfg.Surreal.Namespace).Str("database", cfg.Surreal.Database).Msgf("reconnection failed, attempting to reconnect in %0.2f seconds", nextAttempt.Seconds())
+			},
+		})
 
 	influxRdy := true
 	lpClient, err := influx.NewConnectedClientWithOptions(ctx, cfg.Influx.Url, cfg.Influx.Token, influx.Options{

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -61,6 +61,11 @@ type (
 		Token  string `help:"Influx db token" default:"mir-operator-token" cfg:"secret" yaml:"token"`
 		Org    string `help:"Influx db organisation" default:"Mir" yaml:"org"`
 		Bucket string `help:"Influx db telemetry bucket" default:"mir" yaml:"bucket"`
+
+		BatchSize        uint `help:"Maximum telemetry batch size. Default 1000 datapoints." default:"1000" yaml:"batchSize"`
+		FlushInterval    uint `help:"Maximum telemetry send interval. Default 1 second." default:"1000" yaml:"flushInterval"`
+		RetryBufferLimit uint `help:"Size of buffer in case of database access failure. Default 1GB." default:"1048576000" yaml:"retryBufferLimit"`
+		Gzip             bool `help:"Use gZip compression" default:"false" yaml:"gzip"`
 	}
 )
 
@@ -168,7 +173,12 @@ func run(
 	var lpClient influxdb2.Client
 	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
 		var err error
-		lpClient, err = influx.NewConnectedClient(ctx, cfg.Influx.Url, cfg.Influx.Token)
+		lpClient, err = influx.NewConnectedClientWithOptions(ctx, cfg.Influx.Url, cfg.Influx.Token, influx.Options{
+			BatchSize:        cfg.Influx.BatchSize,
+			FlushInterval:    cfg.Influx.FlushInterval,
+			RetryBufferLimit: cfg.Influx.RetryBufferLimit,
+			UseGZip:          cfg.Influx.Gzip,
+		})
 		return err
 	}); err != nil {
 		db.Close()

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
-	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/externals/ts"
 	"github.com/maxthom/mir/internal/libs/api/health"
@@ -64,7 +64,7 @@ type (
 
 		BatchSize        uint `help:"Maximum telemetry batch size. Default 1000 datapoints." default:"1000" yaml:"batchSize"`
 		FlushInterval    uint `help:"Maximum telemetry send interval. Default 1 second." default:"1000" yaml:"flushInterval"`
-		RetryBufferLimit uint `help:"Size of buffer in case of database access failure. Default 1GB." default:"1048576000" yaml:"retryBufferLimit"`
+		RetryBufferLimit uint `help:"Size of buffer in case of database access failure. Default 1GB." default:"1073741824" yaml:"retryBufferLimit"`
 		Gzip             bool `help:"Use gZip compression" default:"false" yaml:"gzip"`
 	}
 )
@@ -144,14 +144,14 @@ func (d *ServeCmd) Run(log zerolog.Logger, m *mir.Mir, cfg Config) error {
 	log.Info().Str("config", string(prettyCfg)).Msg("")
 	metrics.RegisterMirMetrics(AppName, build_meta.GetShortVersion(), map[string]string{}, string(prettyCfg))
 
-	if err := run(context.Background(), log, m, d.ServeConfig); err != nil {
+	if err := d.run(context.Background(), log, m, d.ServeConfig); err != nil {
 		log.Error().Err(err).Msg("")
 		return err
 	}
 	return nil
 }
 
-func run(
+func (d *ServeCmd) run(
 	ctx context.Context,
 	log zerolog.Logger,
 	m *mir.Mir,
@@ -170,26 +170,29 @@ func run(
 	}
 	log.Info().Str("url", cfg.Surreal.Url).Str("namespace", cfg.Surreal.Namespace).Str("database", cfg.Surreal.Database).Msg("connected to database")
 
-	var lpClient influxdb2.Client
-	if err := external.BackOffRetry(ctx, log, 30*time.Minute, func() error {
-		var err error
-		lpClient, err = influx.NewConnectedClientWithOptions(ctx, cfg.Influx.Url, cfg.Influx.Token, influx.Options{
-			BatchSize:        cfg.Influx.BatchSize,
-			FlushInterval:    cfg.Influx.FlushInterval,
-			RetryBufferLimit: cfg.Influx.RetryBufferLimit,
-			UseGZip:          cfg.Influx.Gzip,
-		})
-		return err
-	}); err != nil {
-		db.Close()
-		return err
+	influxRdy := true
+	lpClient, err := influx.NewConnectedClientWithOptions(ctx, cfg.Influx.Url, cfg.Influx.Token, influx.Options{
+		BatchSize:        cfg.Influx.BatchSize,
+		FlushInterval:    cfg.Influx.FlushInterval,
+		RetryBufferLimit: cfg.Influx.RetryBufferLimit,
+		UseGZip:          cfg.Influx.Gzip,
+	})
+	if err != nil {
+		influxRdy = false
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			log.Warn().Err(err).Str("buffer size (GB)", fmt.Sprintf("%.2f", float64(cfg.Influx.RetryBufferLimit)/1_073_741_824)).Msg("cannot connect to telemetry db, telemetry will be capture and rotated in buffer until connected")
+		} else {
+			return err
+		}
 	}
-	if err := influx.CreateOrgAndBucket(ctx, lpClient, cfg.Influx.Org, cfg.Influx.Bucket); err != nil {
-		return err
+	if influxRdy {
+		if err := influx.CreateOrgAndBucket(ctx, lpClient, cfg.Influx.Org, cfg.Influx.Bucket); err != nil {
+			return err
+		}
+		log.Info().Str("url", cfg.Influx.Url).Msg("connected to puthost")
 	}
-	log.Info().Str("url", cfg.Influx.Url).Msg("connected to puthost")
 
-	m, err := mir.Connect(AppName, cfg.Mir.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)
+	m, err = mir.Connect(AppName, cfg.Mir.Url, append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionLogging(log)...)...)
 	if err != nil {
 		log.Err(err).Msg("error connecting to Mir server")
 		fmt.Println("error connecting to Mir server")

--- a/justfile
+++ b/justfile
@@ -35,6 +35,10 @@ test:
 	go test -coverprofile ./.tmp/coverage.out ./...
 	go tool cover -html ./.tmp/coverage.out
 
+# Start test infra
+test-infra:
+    ./scripts/integration_tests.sh
+
 # Install Mir to path
 install: build-mir
     sudo cp bin/mir /usr/local/bin/mir

--- a/pkgs/device/mir/mir.go
+++ b/pkgs/device/mir/mir.go
@@ -175,12 +175,12 @@ func (m *Mir) Launch(ctx context.Context) (*sync.WaitGroup, error) {
 				if err := m.sendSchema(); err != nil {
 					m.l.Error().Err(err).Msg("error sending schema on connect")
 				}
-				m.l.Debug().Msg("schema updated")
+				m.l.Debug().Msg("schema sent")
 			}
 
 			// Call config handler
 			if err := m.requestDesiredProperties(); err != nil {
-				m.l.Error().Err(err).Msg("error requesting desired properties")
+				m.l.Error().Err(err).Msg("error requesting desired properties, using local")
 			}
 
 			go func() {
@@ -197,7 +197,7 @@ func (m *Mir) Launch(ctx context.Context) (*sync.WaitGroup, error) {
 			time.Sleep(1 * time.Second)
 			m.setOnlineHandler()
 			if err := m.requestDesiredProperties(); err != nil {
-				m.l.Error().Err(err).Msg("error requesting desired properties")
+				m.l.Error().Err(err).Msg("error requesting desired properties, using local")
 			}
 			m.callAllCfgHandlers()
 			m.l.Debug().Msg("desired properties propagated")
@@ -381,10 +381,10 @@ func (m Mir) sendSchema() error {
 func (m Mir) requestDesiredProperties() error {
 	resp, err := cfg_client.PublishRequestDesiredPropertiesStream(m.b.Conn, m.cfg.Device.Id)
 	if err != nil {
-		return fmt.Errorf("error requesting desired properties: %v", err)
+		return err
 	}
 	if resp.GetError() != "" {
-		return fmt.Errorf("error requesting desired properties: %v", resp.GetError())
+		return fmt.Errorf("%s", resp.GetError())
 	}
 
 	props := resp.GetOk()

--- a/pkgs/device/mir/mir_integration_test.go
+++ b/pkgs/device/mir/mir_integration_test.go
@@ -590,7 +590,7 @@ func TestStoreSwapMsgByBatch(t *testing.T) {
 }
 
 func deleteTableOrRecord(db *surrealdb.DB, thing string) error {
-	if _, err := surrealdb.Delete[any](db, thing); err != nil {
+	if _, err := surrealdb.Delete[any](context.Background(), db, thing); err != nil {
 		return err
 	}
 	return nil
@@ -613,7 +613,7 @@ func deleteDevicesDb(t *testing.T, db *surrealdb.DB, ids []string) error {
 
 func executeTestQueryForType[T any](t *testing.T, db *surrealdb.DB, query string, vars map[string]any) T {
 	var empty T
-	result, err := surrealdb.Query[T](db, query, vars)
+	result, err := surrealdb.Query[T](context.Background(), db, query, vars)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkgs/mir_v1/device.go
+++ b/pkgs/mir_v1/device.go
@@ -51,6 +51,11 @@ func (d Device) WithSpec(s DeviceSpec) Device {
 	return d
 }
 
+func (d Device) WithId(id string) Device {
+	d.Spec.DeviceId = id
+	return d
+}
+
 func (d Device) WithProps(p DeviceProperties) Device {
 	d.Properties = p
 	return d
@@ -81,6 +86,16 @@ func (o DeviceTarget) HasNoTarget() bool {
 		len(o.Namespaces) == 0 &&
 		len(o.Labels) == 0 &&
 		len(o.Ids) == 0
+}
+
+func (o DeviceTarget) HasOnlyIdsTarget() bool {
+	if len(o.Names) > 0 || len(o.Namespaces) > 0 || len(o.Labels) > 0 {
+		return false
+	}
+	if len(o.Ids) == 0 {
+		return false
+	}
+	return true
 }
 
 type NameNs struct {

--- a/pkgs/mir_v1/device.go
+++ b/pkgs/mir_v1/device.go
@@ -133,8 +133,8 @@ type DeviceSpec struct {
 }
 
 type DeviceProperties struct {
-	Desired  map[string]interface{} `json:"desired,omitempty" yaml:"desired"`
-	Reported map[string]interface{} `json:"reported,omitempty" yaml:"reported"`
+	Desired  map[string]any `json:"desired,omitempty" yaml:"desired"`
+	Reported map[string]any `json:"reported,omitempty" yaml:"reported"`
 }
 
 type PropertiesTime struct {
@@ -151,10 +151,10 @@ type DeviceStatus struct {
 }
 
 type DeviceStatusEvent struct {
-	Type    EventType                      `json:"type,omitempty" yaml:"type"`
-	Reason  string                         `json:"reason,omitempty" yaml:"reason"`
-	Message string                         `json:"message,omitempty" yaml:"message"`
-	FirstAt surrealdbModels.CustomDateTime `json:"firstAt,omitempty" yaml:"firstAt"`
+	Type    EventType                       `json:"type,omitempty" yaml:"type"`
+	Reason  string                          `json:"reason,omitempty" yaml:"reason"`
+	Message string                          `json:"message,omitempty" yaml:"message"`
+	FirstAt *surrealdbModels.CustomDateTime `json:"firstAt,omitempty" yaml:"firstAt"`
 }
 
 type Schema struct {

--- a/pkgs/mir_v1/transform.go
+++ b/pkgs/mir_v1/transform.go
@@ -90,7 +90,7 @@ func NewDeviceFromProtoDevice(d *mir_apiv1.Device) Device {
 						Type:    e.Type,
 						Message: e.Message,
 						Reason:  e.Reason,
-						FirstAt: surrealdbModels.CustomDateTime{Time: AsGoTime(e.FirstAt)},
+						FirstAt: &surrealdbModels.CustomDateTime{Time: AsGoTime(e.FirstAt)},
 					})
 				}
 			}

--- a/pkgs/module/mir/device.go
+++ b/pkgs/module/mir/device.go
@@ -165,7 +165,7 @@ func (r *schemaRoute) Request(deviceId string) (*mir_proto.MirProtoSchema, error
 		return nil, fmt.Errorf("error deserializing response: %w", err)
 	}
 	if sch.GetError() != "" {
-		return nil, fmt.Errorf("error in device response: %s", sch.GetError())
+		return nil, fmt.Errorf(sch.GetError())
 	}
 
 	return mir_proto.UnmarshalSchema(sch.GetSchema())
@@ -182,7 +182,7 @@ func (r *schemaRoute) Subscribe(deviceId string, h func(msg *Msg, deviceId strin
 	return r.m.subscribe(sbj, r.handlerWrapper(h))
 }
 
-// Subscribe to device reported properties as a worker queue
+// Subscribe to device schema stream
 // To listen to all devices, use deviceId = "" or deviceId = "*"
 // You are responsible of acknowledging the message
 func (r *schemaRoute) QueueSubscribe(queue string, deviceId string, h func(msg *Msg, deviceId string, schema *mir_proto.MirProtoSchema, err error)) error {

--- a/pkgs/module/mir/server_events.go
+++ b/pkgs/module/mir/server_events.go
@@ -1,6 +1,8 @@
 package mir
 
 import (
+	"errors"
+
 	"github.com/maxthom/mir/internal/clients"
 	"github.com/maxthom/mir/internal/clients/event_client"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
@@ -83,7 +85,7 @@ func (r *listEventsRoute) Request(t mir_v1.EventTarget) ([]mir_v1.Event, error) 
 		return []mir_v1.Event{}, err
 	}
 	if resp.GetError() != "" {
-		return []mir_v1.Event{}, err
+		return []mir_v1.Event{}, errors.New(resp.GetError())
 	}
 
 	return mir_v1.ProtoEventsToMirEvents(resp.GetOk().Events), nil
@@ -162,7 +164,7 @@ func (r *deleteEventsRoute) Request(t mir_v1.EventTarget) ([]mir_v1.Event, error
 		return []mir_v1.Event{}, err
 	}
 	if resp.GetError() != "" {
-		return []mir_v1.Event{}, err
+		return []mir_v1.Event{}, errors.New(resp.GetError())
 	}
 
 	return mir_v1.ProtoEventsToMirEvents(resp.GetOk().Events), nil

--- a/pkgs/module/mir/server_tlm_cmd_cfg.go
+++ b/pkgs/module/mir/server_tlm_cmd_cfg.go
@@ -2,6 +2,7 @@ package mir
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/maxthom/mir/internal/clients"
@@ -84,7 +85,7 @@ func (r *listTelemetryRoute) Request(req *mir_apiv1.SendListTelemetryRequest) ([
 		return []*mir_apiv1.DevicesTelemetry{}, err
 	}
 	if resp.GetError() != "" {
-		return []*mir_apiv1.DevicesTelemetry{}, err
+		return []*mir_apiv1.DevicesTelemetry{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DevicesTelemetry, nil
@@ -162,7 +163,7 @@ func (r *listCommandRoute) Request(req *mir_apiv1.SendListCommandsRequest) (map[
 		return map[string]*mir_apiv1.Commands{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.Commands{}, err
+		return map[string]*mir_apiv1.Commands{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DeviceCommands, nil
@@ -238,7 +239,7 @@ func (r *sendCommandRoute) Request(req *mir_apiv1.SendCommandRequest) (map[strin
 		return map[string]*mir_apiv1.SendCommandResponse_CommandResponse{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.SendCommandResponse_CommandResponse{}, err
+		return map[string]*mir_apiv1.SendCommandResponse_CommandResponse{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DeviceResponses, nil
@@ -342,7 +343,7 @@ func (r *listConfigurationRoute) Request(req *mir_apiv1.SendListConfigRequest) (
 		return map[string]*mir_apiv1.Configs{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.Configs{}, err
+		return map[string]*mir_apiv1.Configs{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DeviceConfigs, nil
@@ -418,7 +419,7 @@ func (r *sendConfigRoute) Request(req *mir_apiv1.SendConfigRequest) (map[string]
 		return map[string]*mir_apiv1.SendConfigResponse_ConfigResponse{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.SendConfigResponse_ConfigResponse{}, err
+		return map[string]*mir_apiv1.SendConfigResponse_ConfigResponse{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DeviceResponses, nil


### PR DESCRIPTION
## Summary
- Implemented automatic reconnection for SurrealDB across all services (core, eventstore, protocfg, protocmd, prototlm)
- Added automatic reconnection and retry logic for InfluxDB with configurable buffer settings
- Services can now run in degraded mode when databases are temporarily unavailable
- Enhanced connection handling with proper logging for connection states

## Changes

### SurrealDB Auto-reconnection
- Created new `surreal.AutoReconnDB` wrapper that maintains persistent connections
- Added connection handlers for connected, disconnected, and failed reconnect events
- Removed manual backoff retry logic in favor of built-in reconnection
- Services continue operating in degraded mode when SurrealDB is unavailable

### InfluxDB Auto-reconnection  
- Added retry buffer configuration (default 1GB) to store telemetry during disconnections
- Implemented connection options for batch size, flush interval, and compression
- ProtoTlm service can start even if InfluxDB is initially unavailable
- Telemetry data is buffered and automatically sent when connection is restored

### Docker Improvements
- Added comprehensive metadata labels to Docker images
- Labels include title, description, vendor, documentation URL, and license
- Improved container discoverability and compliance

## Test plan
- [x] Test SurrealDB reconnection by stopping/starting the database
- [x] Test InfluxDB reconnection and verify buffered data is sent
- [x] Verify services start successfully even when databases are offline
- [x] Check degraded mode operation for each service
- [x] Validate Docker image labels are correctly applied

🤖 Generated with [Claude Code](https://claude.ai/code)