### PR TITLE
feat: Update Helm chart versioning logic

### DIFF
--- a/.github/workflows/helm-mir-chart.yaml
+++ b/.github/workflows/helm-mir-chart.yaml
@@ -36,7 +36,7 @@ jobs:
           # Extract version from Chart.yaml
           CURRENT_VERSION=$(grep '^version:' ${{ env.CHART_PATH }}/Chart.yaml | sed 's/version: //')
           echo "Current chart version in Chart.yaml: ${CURRENT_VERSION}"
-          
+
           # Parse major and minor version
           if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
             CURRENT_MAJOR="${BASH_REMATCH[1]}"
@@ -48,7 +48,7 @@ jobs:
             CURRENT_MINOR="2"
             echo "Warning: Could not parse version, using fallback: ${CURRENT_MAJOR}.${CURRENT_MINOR}"
           fi
-          
+
           echo "major=${CURRENT_MAJOR}" >> $GITHUB_OUTPUT
           echo "minor=${CURRENT_MINOR}" >> $GITHUB_OUTPUT
 
@@ -74,36 +74,51 @@ jobs:
             ALL_VERSIONS="$response"
           fi
 
+          echo $LATEST_VERSION
+          echo $ALL_VERSIONS
           echo "latest=${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "all_versions=${ALL_VERSIONS}" >> $GITHUB_OUTPUT
+          echo "all_versions=$(echo "$ALL_VERSIONS" | base64 -w 0)" >> $GITHUB_OUTPUT
 
       - name: Set chart version
         id: chartversion
         run: |
           LATEST="${{ steps.latestversion.outputs.latest }}"
-          ALL_VERSIONS="${{ steps.latestversion.outputs.all_versions }}"
+          ALL_VERSIONS=$(echo "${{ steps.latestversion.outputs.all_versions }}" | base64 -d)
           CURRENT_MAJOR="${{ steps.currentversion.outputs.major }}"
           CURRENT_MINOR="${{ steps.currentversion.outputs.minor }}"
 
           # For production releases (tags), use Chart.yaml major.minor with ChartMuseum patch
           if [[ "${{ github.ref_type }}" == "tag" ]] || [[ "${{ github.event_name }}" == "release" ]]; then
 
-            # Parse the latest version from ChartMuseum to get the patch
+            # Parse the latest version from ChartMuseum to check major.minor
             if [[ "$LATEST" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+              MUSEUM_MAJOR="${BASH_REMATCH[1]}"
+              MUSEUM_MINOR="${BASH_REMATCH[2]}"
               MUSEUM_PATCH="${BASH_REMATCH[3]}"
             else
+              MUSEUM_MAJOR="0"
+              MUSEUM_MINOR="0"
               MUSEUM_PATCH="0"
             fi
 
-            # Construct the new version using Chart.yaml major.minor and ChartMuseum patch
-            CHART_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${MUSEUM_PATCH}"
-            
+            # Check if ChartMuseum's major.minor matches Chart.yaml's major.minor
+            if [[ "$MUSEUM_MAJOR" == "$CURRENT_MAJOR" ]] && [[ "$MUSEUM_MINOR" == "$CURRENT_MINOR" ]]; then
+              # Same major.minor, use the ChartMuseum patch
+              BASE_PATCH="$MUSEUM_PATCH"
+            else
+              # Different major.minor, start with patch 0
+              BASE_PATCH="0"
+            fi
+
+            # Construct the new version using Chart.yaml major.minor and determined patch
+            CHART_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${BASE_PATCH}"
+
             # Check if this version already exists in ChartMuseum
             VERSION_EXISTS=$(echo "$ALL_VERSIONS" | jq -r --arg v "$CHART_VERSION" '.[] | select(.version == $v) | .version' || echo "")
-            
+
             if [ -n "$VERSION_EXISTS" ]; then
               echo "Version ${CHART_VERSION} already exists in ChartMuseum, incrementing patch"
-              PATCH=$((MUSEUM_PATCH + 1))
+              PATCH=$((BASE_PATCH + 1))
               CHART_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${PATCH}"
             else
               echo "Version ${CHART_VERSION} does not exist in ChartMuseum, using as-is"
@@ -116,29 +131,36 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             BRANCH_NAME=${GITHUB_REF#refs/heads/}
             # Replace slashes with double underscores
-            BRANCH_NAME=${BRANCH_NAME//\//__}
+            BRANCH_NAME_APP=${BRANCH_NAME//\//__}
+            BRANCH_NAME_CHART=${BRANCH_NAME//\//--}
             SHORT_SHA=${GITHUB_SHA::7}
 
-            # Use the constructed version as base
+            # Parse the latest ChartMuseum version to check if major.minor matches
             if [[ "$LATEST" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+              MUSEUM_MAJOR="${BASH_REMATCH[1]}"
+              MUSEUM_MINOR="${BASH_REMATCH[2]}"
               MUSEUM_PATCH="${BASH_REMATCH[3]}"
             else
+              MUSEUM_MAJOR="0"
+              MUSEUM_MINOR="0"
               MUSEUM_PATCH="0"
             fi
-            
-            # Construct base version
-            BASE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${MUSEUM_PATCH}"
-            
-            # Check if this exact version exists
-            VERSION_EXISTS=$(echo "$ALL_VERSIONS" | jq -r --arg v "$BASE_VERSION" '.[] | select(.version == $v) | .version' || echo "")
-            
-            if [ -n "$VERSION_EXISTS" ]; then
-              PATCH=$((MUSEUM_PATCH + 1))
-              BASE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${PATCH}"
+
+            # Check if ChartMuseum's major.minor matches Chart.yaml's major.minor
+            if [[ "$MUSEUM_MAJOR" == "$CURRENT_MAJOR" ]] && [[ "$MUSEUM_MINOR" == "$CURRENT_MINOR" ]]; then
+              # Same major.minor, use the ChartMuseum patch
+              BASE_PATCH="$MUSEUM_PATCH"
+            else
+              # Different major.minor, start with patch 0
+              BASE_PATCH="0"
             fi
 
-            CHART_VERSION="${BASE_VERSION}-${BRANCH_NAME}.${SHORT_SHA}"
-            APP_VERSION="${BRANCH_NAME}--${SHORT_SHA}"
+            # Construct base version
+            BASE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${BASE_PATCH}"
+
+            # For manual triggers, we don't increment - branch and commit make it unique
+            CHART_VERSION="${BASE_VERSION}-${BRANCH_NAME_CHART}+${SHORT_SHA}"
+            APP_VERSION="${BRANCH_NAME_APP}--${SHORT_SHA}"
           fi
 
           echo "version=${CHART_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/helm-mir-chart.yaml
+++ b/.github/workflows/helm-mir-chart.yaml
@@ -30,6 +30,28 @@ jobs:
           helm repo add influxdata https://helm.influxdata.com/
           helm repo update
 
+      - name: Get current chart version from Chart.yaml
+        id: currentversion
+        run: |
+          # Extract version from Chart.yaml
+          CURRENT_VERSION=$(grep '^version:' ${{ env.CHART_PATH }}/Chart.yaml | sed 's/version: //')
+          echo "Current chart version in Chart.yaml: ${CURRENT_VERSION}"
+          
+          # Parse major and minor version
+          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+            CURRENT_MAJOR="${BASH_REMATCH[1]}"
+            CURRENT_MINOR="${BASH_REMATCH[2]}"
+            echo "Extracted major.minor: ${CURRENT_MAJOR}.${CURRENT_MINOR}"
+          else
+            # Fallback if version doesn't match semver
+            CURRENT_MAJOR="0"
+            CURRENT_MINOR="2"
+            echo "Warning: Could not parse version, using fallback: ${CURRENT_MAJOR}.${CURRENT_MINOR}"
+          fi
+          
+          echo "major=${CURRENT_MAJOR}" >> $GITHUB_OUTPUT
+          echo "minor=${CURRENT_MINOR}" >> $GITHUB_OUTPUT
+
       - name: Get latest chart version from ChartMuseum
         id: latestversion
         run: |
@@ -43,32 +65,48 @@ jobs:
           if [ -z "$response" ] || [ "$response" = "[]" ]; then
             echo "No existing chart found, starting with version 0.1.0"
             LATEST_VERSION="0.0.0"
+            ALL_VERSIONS="[]"
           else
             # Extract the latest version (first in the array, as ChartMuseum returns sorted)
             LATEST_VERSION=$(echo "$response" | jq -r '.[0].version // "0.0.0"')
             echo "Found latest version: ${LATEST_VERSION}"
+            # Store all versions for later checking
+            ALL_VERSIONS="$response"
           fi
 
           echo "latest=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "all_versions=${ALL_VERSIONS}" >> $GITHUB_OUTPUT
 
       - name: Set chart version
         id: chartversion
         run: |
           LATEST="${{ steps.latestversion.outputs.latest }}"
+          ALL_VERSIONS="${{ steps.latestversion.outputs.all_versions }}"
+          CURRENT_MAJOR="${{ steps.currentversion.outputs.major }}"
+          CURRENT_MINOR="${{ steps.currentversion.outputs.minor }}"
 
-          # For production releases (tags), increment patch version
+          # For production releases (tags), use Chart.yaml major.minor with ChartMuseum patch
           if [[ "${{ github.ref_type }}" == "tag" ]] || [[ "${{ github.event_name }}" == "release" ]]; then
 
-            # Parse semantic version and increment patch
+            # Parse the latest version from ChartMuseum to get the patch
             if [[ "$LATEST" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              PATCH="${BASH_REMATCH[3]}"
-              PATCH=$((PATCH + 1))
-              CHART_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+              MUSEUM_PATCH="${BASH_REMATCH[3]}"
             else
-              # If version doesn't match semver, start fresh
-              CHART_VERSION="0.1.0"
+              MUSEUM_PATCH="0"
+            fi
+
+            # Construct the new version using Chart.yaml major.minor and ChartMuseum patch
+            CHART_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${MUSEUM_PATCH}"
+            
+            # Check if this version already exists in ChartMuseum
+            VERSION_EXISTS=$(echo "$ALL_VERSIONS" | jq -r --arg v "$CHART_VERSION" '.[] | select(.version == $v) | .version' || echo "")
+            
+            if [ -n "$VERSION_EXISTS" ]; then
+              echo "Version ${CHART_VERSION} already exists in ChartMuseum, incrementing patch"
+              PATCH=$((MUSEUM_PATCH + 1))
+              CHART_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${PATCH}"
+            else
+              echo "Version ${CHART_VERSION} does not exist in ChartMuseum, using as-is"
             fi
 
             # Set app version from tag
@@ -81,11 +119,22 @@ jobs:
             BRANCH_NAME=${BRANCH_NAME//\//__}
             SHORT_SHA=${GITHUB_SHA::7}
 
-            # Use latest version as base, or 0.1.0 if none exists
-            if [[ "$LATEST" == "0.0.0" ]]; then
-              BASE_VERSION="0.1.0"
+            # Use the constructed version as base
+            if [[ "$LATEST" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+              MUSEUM_PATCH="${BASH_REMATCH[3]}"
             else
-              BASE_VERSION="$LATEST"
+              MUSEUM_PATCH="0"
+            fi
+            
+            # Construct base version
+            BASE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${MUSEUM_PATCH}"
+            
+            # Check if this exact version exists
+            VERSION_EXISTS=$(echo "$ALL_VERSIONS" | jq -r --arg v "$BASE_VERSION" '.[] | select(.version == $v) | .version' || echo "")
+            
+            if [ -n "$VERSION_EXISTS" ]; then
+              PATCH=$((MUSEUM_PATCH + 1))
+              BASE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${PATCH}"
             fi
 
             CHART_VERSION="${BASE_VERSION}-${BRANCH_NAME}.${SHORT_SHA}"

--- a/infra/k8s/charts/mir/Chart.yaml
+++ b/infra/k8s/charts/mir/Chart.yaml
@@ -3,7 +3,7 @@ name: mir
 description: A Helm chart for Mir IoT Platform for Kubernetes
 type: application
 
-version: 0.2.0
+version: 0.1.0
 appVersion: "v0.3.5"
 
 dependencies:

--- a/infra/k8s/charts/mir/Chart.yaml
+++ b/infra/k8s/charts/mir/Chart.yaml
@@ -3,7 +3,7 @@ name: mir
 description: A Helm chart for Mir IoT Platform for Kubernetes
 type: application
 
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.3.5"
 
 dependencies:


### PR DESCRIPTION
## Summary

- Updated Helm chart versioning workflow to use Chart.yaml major.minor version combined with ChartMuseum patch version
- Prevents version conflicts by checking if version already exists before using it
- Maintains branch-based versioning for manual workflow triggers

## Changes

### Production Releases (tags/releases)
- Takes `major.minor` from the Chart.yaml file (currently 0.2)
- Takes `patch` version from the latest version in ChartMuseum
- If the constructed version already exists, increments the patch by 1
- Example: Chart.yaml=0.2.0, ChartMuseum latest=0.1.5 → Version=0.2.0
- Example: Chart.yaml=0.2.0, ChartMuseum latest=0.2.0 → Version=0.2.1

### Manual Triggers (workflow_dispatch)
- Uses the same base version logic (major.minor from Chart.yaml, patch from ChartMuseum)
- Appends branch name and commit SHA for development versions
- Example: Base=0.2.0, Branch=feature/helm-pipe → Version=0.2.0-feature__helm-pipe.abc1234

## Implementation Details
1. Added step to read and parse Chart.yaml to extract major.minor version
2. Modified version calculation to combine Chart.yaml major.minor with ChartMuseum patch
3. Added existence check using ChartMuseum API to prevent version conflicts
4. Preserved branch-based versioning for manual triggers

This ensures consistent versioning across releases while preventing version conflicts in the chart repository.

🤖 Generated with [Claude Code](https://claude.ai/code)