### PR TITLE
feat: add pprof profiling support to all services

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,6 @@
+# Usage
+
+## pprof
+
+set -gx GO_PPROF on
+pprof -seconds 10 -http=localhost:8181 http://localhost:3015/debug/pprof/profile

--- a/cmds/core/main.go
+++ b/cmds/core/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_cli"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
@@ -189,6 +190,7 @@ func run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{

--- a/cmds/eventstore/main.go
+++ b/cmds/eventstore/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_cli"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
@@ -189,6 +190,7 @@ func run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{

--- a/cmds/protocfg/main.go
+++ b/cmds/protocfg/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_cli"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
@@ -194,6 +195,7 @@ func run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{

--- a/cmds/protocmd/main.go
+++ b/cmds/protocmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_cli"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
@@ -194,6 +195,7 @@ func run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{

--- a/cmds/prototlm/main.go
+++ b/cmds/prototlm/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/ts"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_cli"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
@@ -245,6 +246,7 @@ func run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{

--- a/internal/libs/api/pprof/pprof.go
+++ b/internal/libs/api/pprof/pprof.go
@@ -1,0 +1,65 @@
+// Package pprof provides HTTP handlers for runtime profiling data.
+// It wraps the standard net/http/pprof package handlers and provides
+// a convenient RegisterRoutes function to register all pprof endpoints.
+package pprof
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"os"
+)
+
+// RegisterRoutes registers all pprof HTTP handlers on the provided mux.
+// This includes:
+//   - /debug/pprof/           - Shows index page with list of available profiles
+//   - /debug/pprof/cmdline    - Shows the command line invocation of the current program
+//   - /debug/pprof/profile    - CPU profile (default 30s, configurable via ?seconds=N)
+//   - /debug/pprof/symbol     - Symbol lookup for program counters
+//   - /debug/pprof/trace      - Execution trace (default 1s, configurable via ?seconds=N)
+//
+// And runtime profiles accessible via /debug/pprof/{profile}:
+//   - goroutine    - Stack traces of all current goroutines
+//   - heap         - Heap memory allocations sampling
+//   - allocs       - All past memory allocations sampling
+//   - threadcreate - Stack traces that led to thread creation
+//   - block        - Stack traces that led to blocking on synchronization primitives
+//   - mutex        - Stack traces of holders of contended mutexes
+//
+// Security Note: These endpoints expose sensitive debugging information and
+// should only be accessible in development or on a secured internal port.
+func RegisterRoutes(mux *http.ServeMux) {
+	// Register the index handler
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+
+	// Register specific endpoint handlers
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// Note: The runtime profiles (goroutine, heap, allocs, threadcreate, block, mutex)
+	// are automatically handled by pprof.Index and don't need separate registration.
+	// They are accessible via /debug/pprof/{profile_name}
+}
+
+// RegisterRoutesIfEnvGoPprofSet conditionally registers all pprof HTTP handlers
+// on the provided mux only if the GO_PPROF environment variable is set to a
+// non-empty value. This provides a convenient way to enable profiling endpoints
+// in production environments without code changes.
+//
+// Usage:
+//   - Set GO_PPROF=1 (or any non-empty value) to enable profiling endpoints
+//   - Leave GO_PPROF unset or empty to disable profiling endpoints
+//
+// This is useful for production deployments where you want the ability to
+// enable profiling on demand without redeploying or modifying code.
+//
+// Security Note: The same security considerations apply as with RegisterRoutes.
+// Ensure proper access controls are in place when enabling in production.
+func RegisterRoutesIfEnvGoPprofSet(mux *http.ServeMux) {
+	if os.Getenv("GO_PPROF") == "" {
+		return
+	}
+
+	RegisterRoutes(mux)
+}

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/maxthom/mir/internal/externals/ts"
 	"github.com/maxthom/mir/internal/libs/api/health"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/api/pprof"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_config"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_log"
 	"github.com/maxthom/mir/internal/libs/boiler/mir_signals"
@@ -244,6 +245,7 @@ func (d *ServeCmd) run(
 	mux := http.NewServeMux()
 	metrics.RegisterRoutes(mux)
 	health.RegisterRoutes(mux)
+	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// WebServer
 	server := &http.Server{


### PR DESCRIPTION
## Summary
- Added conditional pprof profiling endpoints to all Mir services
- Profiling is only enabled when `GO_PPROF` environment variable is set
- Allows production performance debugging without code changes

## Changes
- Created new `internal/libs/api/pprof` package with `RegisterRoutesIfEnvGoPprofSet` function
- Added pprof route registration to all service HTTP servers (core, eventstore, protocfg, protocmd, prototlm)
- Added pprof support to CLI serve command
- Added USAGE.md with instructions on how to use pprof

## Test plan
- [ ] Set `GO_PPROF=on` environment variable
- [ ] Start services with `mir serve`
- [ ] Verify pprof endpoints are accessible at `http://localhost:3015/debug/pprof/`
- [ ] Test CPU profiling with `pprof -seconds 10 -http=localhost:8181 http://localhost:3015/debug/pprof/profile`
- [ ] Verify endpoints are NOT accessible when `GO_PPROF` is unset

🤖 Generated with [Claude Code](https://claude.ai/code)