### PR TITLE
feat: add event buffering for database disconnections

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -16,17 +16,10 @@
   - [ ] alert & alarms
   - [ ] perf test
   - [ ] autoreconnect
-    - [ ] nats
-      - [ ] switch to jetstream for tlm
-    - [ ] during
-      - [ ] surreal
-        - [ ] accumulate events in a buffer, event from cmd
-            - [ ] Add that events can be sent without related object
-              - [ ] Check to send event in degraded (cmd, online, offline)
-            - [x] Have a event buffer
-              - [ ] add buffer metric
-            - [ ] Testing Auto
-
+    - [ ] if modules are down
+      - [ ] switch to jetstream for tlm, could be in memory TLM
+        - must add jetstream functions to ModuleSDK
+        - update routes to use jetstream, hearthbeat, tlm, reported properties
 
 ### Refactoring
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,16 +5,16 @@
 ### Bug
 
 - [ ] Add deviceid to badger
+- [ ] core bug with reconnect of loading devices
 
 ### Features
 
 - [ ] MCP Server for Mir
 - [ ] TinyGo
 - [ ] Road to Production
-  - [x] Module SDK Server rename to Client
-  - [ ] core bug with reconnect of loading devices
-  - [x] is connected to surreal on start? do random query to try
   - [ ] docs
+  - [ ] alert & alarms
+  - [ ] perf test
   - [ ] autoreconnect
     - [ ] nats
       - [ ] switch to jetstream for tlm
@@ -22,11 +22,9 @@
       - [ ] surreal
         - [ ] accumulate events in a buffer, event from cmd
             - [ ] Add that events can be sent without related object
-            - [ ] Have a event buffer
-            - [ ] events
-              - [ ] online
-              - [ ] offline
-              - [ ] cmd send
+              - [ ] Check to send event in degraded (cmd, online, offline)
+            - [x] Have a event buffer
+            - [ ] Testing Auto
 
 
 ### Refactoring

--- a/TASKS.md
+++ b/TASKS.md
@@ -24,6 +24,7 @@
             - [ ] Add that events can be sent without related object
               - [ ] Check to send event in degraded (cmd, online, offline)
             - [x] Have a event buffer
+              - [ ] add buffer metric
             - [ ] Testing Auto
 
 

--- a/cmds/playground/main.go
+++ b/cmds/playground/main.go
@@ -1,58 +1,35 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 
-	"github.com/maxthom/mir/internal/libs/jsonyaml"
-	"gopkg.in/yaml.v3"
+	"github.com/maxthom/mir/pkgs/mir_v1"
+	"github.com/maxthom/mir/pkgs/module/mir"
 )
-
-type Event struct {
-	Name       string
-	FamilyName string
-	Age        int
-	Json       jsonyaml.RawMessage `yaml:"-"`
-}
 
 func main() {
 
-	e := Event{
-		Name:       "Max",
-		FamilyName: "Thom",
-		Age:        24,
+	m, err := mir.Connect("playground", "nats://localhost:4222")
+	if err != nil {
+		panic(err)
 	}
 
-	// Create a random JSON object
-	randomJsonObj := map[string]any{
-		"id":        123456,
-		"active":    true,
-		"score":     98.76,
-		"tags":      []string{"golang", "json", "random"},
-		"timestamp": "2023-08-15T14:22:31Z",
-		"address": map[string]any{
-			"street":  "123 Main St",
-			"city":    "Techville",
-			"zipcode": 10101,
-		},
-		"metadata": map[string]any{
-			"version": 2.1,
-			"debug":   false,
-			"counts":  []int{1, 2, 3, 4, 5},
-		},
-		"nullable": nil,
+	for i := range 120 {
+		time.Sleep(time.Millisecond * 100)
+		fmt.Println(i)
+		if err := m.Event().Publish(m.Event().NewSubject(strconv.Itoa(i), "playground", "v1", "test"),
+			mir_v1.EventSpec{
+				Type:    mir_v1.EventTypeNormal,
+				Reason:  "test",
+				Message: "testing buffer",
+				// Payload:       jsonyaml.RawMessage{},
+				// RelatedObject: mir_v1.Object{},
+			}, nil); err != nil {
+			fmt.Println(err)
+		}
 	}
 
-	// Convert map to JSON and assign to Event.Json
-	jsonData, _ := json.Marshal(randomJsonObj)
-	e.Json = jsonyaml.RawMessage(jsonData)
-
-	b, err := json.MarshalIndent(e, "", "  ")
-	fmt.Println(err)
-	fmt.Println(string(b))
-
-	y, err := yaml.Marshal(e)
-	fmt.Println(err)
-	fmt.Println(string(y))
-
+	fmt.Println("done")
 }

--- a/infra/compose/promstack/grafana_provisioning/provisioning/dashboards/mir/eventstore.json
+++ b/infra/compose/promstack/grafana_provisioning/provisioning/dashboards/mir/eventstore.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 20,
+  "id": 17,
   "links": [
     {
       "asDropdown": true,
@@ -112,7 +112,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -239,7 +239,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -302,7 +302,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -368,7 +368,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -434,7 +434,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -527,7 +527,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -637,7 +637,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -736,7 +736,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -751,6 +751,105 @@
         }
       ],
       "title": "Event Capture Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Buffer is used to accumulate events in case of database disconnect",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 15
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(mir_eventstore_event_buffer_size{job=\"${job}\"})",
+          "legendFormat": "count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Event Buffer Size",
       "type": "timeseries"
     },
     {
@@ -817,8 +916,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 15
       },
       "id": 12,
@@ -835,7 +934,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -916,8 +1015,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 15
       },
       "id": 10,
@@ -934,7 +1033,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1015,8 +1114,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 15
       },
       "id": 11,
@@ -1033,7 +1132,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1077,7 +1176,7 @@
         "sortOrder": "Ascending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1157,5 +1256,5 @@
   "timezone": "browser",
   "title": "EventStore",
   "uid": "815b2d90-e36a-4a0c-8508-3d507f62dc7a",
-  "version": 1
+  "version": 2
 }

--- a/infra/k8s/charts/mir/dashboards/mir/eventstore.json
+++ b/infra/k8s/charts/mir/dashboards/mir/eventstore.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 20,
+  "id": 17,
   "links": [
     {
       "asDropdown": true,
@@ -112,7 +112,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -239,7 +239,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -302,7 +302,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -368,7 +368,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -434,7 +434,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -527,7 +527,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "editorMode": "code",
@@ -637,7 +637,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -736,7 +736,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -751,6 +751,105 @@
         }
       ],
       "title": "Event Capture Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Buffer is used to accumulate events in case of database disconnect",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 15
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(mir_eventstore_event_buffer_size{job=\"${job}\"})",
+          "legendFormat": "count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Event Buffer Size",
       "type": "timeseries"
     },
     {
@@ -817,8 +916,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 15
       },
       "id": 12,
@@ -835,7 +934,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -916,8 +1015,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 15
       },
       "id": 10,
@@ -934,7 +1033,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1015,8 +1114,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 15
       },
       "id": 11,
@@ -1033,7 +1132,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1077,7 +1176,7 @@
         "sortOrder": "Ascending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
@@ -1157,5 +1256,5 @@
   "timezone": "browser",
   "title": "EventStore",
   "uid": "815b2d90-e36a-4a0c-8508-3d507f62dc7a",
-  "version": 1
+  "version": 2
 }

--- a/internal/externals/mng/abstract.go
+++ b/internal/externals/mng/abstract.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"regexp"
 
+	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 )
@@ -31,6 +32,9 @@ type MirStore interface {
 	UpdateEvent(t mir_v1.ObjectTarget, upd mir_v1.EventUpdate) ([]mir_v1.Event, error)
 	MergeEvent(t mir_v1.ObjectTarget, patch json.RawMessage, op UpdateType) ([]mir_v1.Event, error)
 	DeleteEvent(t mir_v1.EventTarget) ([]mir_v1.Event, error)
+
+	Status() external.ConnectionStatus
+	StatusSubscribe() <-chan external.ConnectionStatus
 }
 
 type surrealMirStore struct {
@@ -41,4 +45,12 @@ func NewSurrealMirStore(db *surreal.AutoReconnDB) *surrealMirStore {
 	return &surrealMirStore{
 		db: db,
 	}
+}
+
+func (s *surrealMirStore) Status() external.ConnectionStatus {
+	return s.db.ConnStatus
+}
+
+func (s *surrealMirStore) StatusSubscribe() <-chan external.ConnectionStatus {
+	return s.db.StatusSubscribe()
 }

--- a/internal/libs/external/surreal/surreal.go
+++ b/internal/libs/external/surreal/surreal.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/libs/resync"
 	"github.com/rs/zerolog"
 	"github.com/surrealdb/surrealdb.go"
@@ -14,42 +15,14 @@ import (
 
 var ErrDatabaseDisconnected = fmt.Errorf("database disconnected")
 
-type ConnectionStatus int
-
-const (
-	// Connection is connected
-	StatusConnected ConnectionStatus = iota
-	// Connection is disconnected and not trying to reconnect
-	StatusDisconnected
-	// Connection is attempting to reconnect
-	StatusReconnecting
-	// Connection cannot authentified itself to the db
-	StatusNotAuthenticated
-	// Connection is purposfully closed
-	StatusClosed
-)
-
-func (s ConnectionStatus) String() string {
-	switch s {
-	case StatusDisconnected:
-		return "Disconnected"
-	case StatusConnected:
-		return "Connected"
-	case StatusNotAuthenticated:
-		return "NotAuthenticated"
-	case StatusClosed:
-		return "Closed"
-	default:
-		return "Unknown"
-	}
-}
-
 type AutoReconnDB struct {
 	*surrealdb.DB
+	statusSubs  []chan external.ConnectionStatus
+	statusMu    sync.RWMutex
 	dbMu        sync.RWMutex
 	ctx         context.Context
 	log         zerolog.Logger
-	ConnStatus  ConnectionStatus
+	ConnStatus  external.ConnectionStatus
 	once        resync.Once
 	isConn      bool
 	connHandler ConnHandler
@@ -87,7 +60,7 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 		d := &AutoReconnDB{
 			DB:          db,
 			ctx:         ctx,
-			ConnStatus:  StatusDisconnected,
+			ConnStatus:  external.StatusDisconnected,
 			connHandler: h,
 			Url:         url,
 			User:        user,
@@ -105,7 +78,7 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 		d := &AutoReconnDB{
 			DB:          db,
 			ctx:         ctx,
-			ConnStatus:  StatusNotAuthenticated,
+			ConnStatus:  external.StatusNotAuthenticated,
 			connHandler: h,
 			Url:         url,
 			User:        user,
@@ -120,7 +93,7 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 		return &AutoReconnDB{
 			DB:          db,
 			ctx:         ctx,
-			ConnStatus:  StatusConnected,
+			ConnStatus:  external.StatusConnected,
 			connHandler: h,
 			isConn:      true,
 			Url:         url,
@@ -134,7 +107,7 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 	return &AutoReconnDB{
 		DB:          db,
 		ctx:         ctx,
-		ConnStatus:  StatusConnected,
+		ConnStatus:  external.StatusConnected,
 		connHandler: h,
 		isConn:      true,
 		Url:         url,
@@ -146,11 +119,21 @@ func connect(ctx context.Context, url, namespace, database, user, password strin
 }
 
 func (db *AutoReconnDB) Close() error {
-	db.dbMu.RLock()
-	defer db.dbMu.RUnlock()
+	db.dbMu.Lock()
+	defer db.dbMu.Unlock()
+	db.statusMu.Lock()
+	defer db.statusMu.Unlock()
+
+	db.ConnStatus = external.StatusClosed
+	for _, ch := range db.statusSubs {
+		ch <- db.ConnStatus
+		close(ch)
+	}
+
 	if db.DB == nil {
 		return nil
 	}
+
 	return db.DB.Close(db.ctx)
 }
 
@@ -158,6 +141,10 @@ func (db *AutoReconnDB) monitorAndReconnect() {
 	db.isConn = false
 	fnM := func() {
 		go func() {
+			db.ConnStatus = external.StatusDisconnected
+			for _, ch := range db.statusSubs {
+				ch <- db.ConnStatus
+			}
 			if db.connHandler.FnDisconnected != nil {
 				db.connHandler.FnDisconnected(db.Url)
 			}
@@ -172,6 +159,11 @@ func (db *AutoReconnDB) monitorAndReconnect() {
 					d, err := connect(db.ctx, db.Url, db.Namespace, db.Database, db.User, db.Password, db.connHandler)
 					db.dbMu.Lock()
 					db.DB = d.DB
+					if db.ConnStatus != d.ConnStatus {
+						for _, ch := range db.statusSubs {
+							ch <- d.ConnStatus
+						}
+					}
 					db.ConnStatus = d.ConnStatus
 					db.dbMu.Unlock()
 					if err != nil {
@@ -192,6 +184,14 @@ func (db *AutoReconnDB) monitorAndReconnect() {
 		}()
 	}
 	db.once.Do(fnM)
+}
+
+func (db *AutoReconnDB) StatusSubscribe() <-chan external.ConnectionStatus {
+	ch := make(chan external.ConnectionStatus, 10) // Buffered to prevent blocking
+	db.statusMu.Lock()
+	db.statusSubs = append(db.statusSubs, ch)
+	db.statusMu.Unlock()
+	return ch
 }
 
 func Create[T any, TWhat surrealdb.TableOrRecord](db *AutoReconnDB, what TWhat, data any) (*T, error) {

--- a/internal/libs/external/utils.go
+++ b/internal/libs/external/utils.go
@@ -8,28 +8,58 @@ import (
 	"github.com/rs/zerolog"
 )
 
+type ConnectionStatus int
+
+const (
+	// Connection is connected
+	StatusConnected ConnectionStatus = iota
+	// Connection is disconnected and not trying to reconnect
+	StatusDisconnected
+	// Connection is attempting to reconnect
+	StatusReconnecting
+	// Connection cannot authentified itself to the db
+	StatusNotAuthenticated
+	// Connection is purposfully closed
+	StatusClosed
+)
+
+func (s ConnectionStatus) String() string {
+	switch s {
+	case StatusDisconnected:
+		return "Disconnected"
+	case StatusConnected:
+		return "Connected"
+	case StatusNotAuthenticated:
+		return "NotAuthenticated"
+	case StatusClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
 // CallWithTimeout executes a function with a timeout and returns the result or an error if it times out
 func CallWithTimeout[T any](ctx context.Context, timeout time.Duration, fn func() (T, error)) (T, error) {
 	var zero T
-	
+
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	
+
 	// Result channel
 	type result struct {
 		value T
 		err   error
 	}
-	
+
 	resultChan := make(chan result, 1)
-	
+
 	// Execute function in goroutine
 	go func() {
 		value, err := fn()
 		resultChan <- result{value: value, err: err}
 	}()
-	
+
 	// Wait for result or timeout
 	select {
 	case <-ctx.Done():

--- a/internal/servers/core_srv/server.go
+++ b/internal/servers/core_srv/server.go
@@ -12,17 +12,13 @@ import (
 	"github.com/maxthom/mir/internal/clients/core_client"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
-	bus "github.com/maxthom/mir/internal/libs/external/natsio"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/maxthom/mir/pkgs/module/mir"
-	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	surrealdbModels "github.com/surrealdb/surrealdb.go/pkg/models"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // How to make this service scalable
@@ -326,7 +322,14 @@ func (s *CoreServer) hearthbeatPulsor(ctx context.Context, interval time.Duratio
 					if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 						l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
 					}
-					continue
+					// Degraded mode
+					devs = make([]mir_v1.Device, len(newOffline))
+					for i, id := range newOffline {
+						devs[i] = mir_v1.NewDevice().WithId(id).WithMeta(mir_v1.Meta{
+							Name:      id,
+							Namespace: "__degraded",
+						})
+					}
 				}
 				l.Info().Str("route", "hearthbeat_pulsor").Str("event", "device_offline").Strs("new devices", newOffline).Msg("offline devices")
 				s.hearthbeatsMutex.Lock()
@@ -348,6 +351,7 @@ func (s *CoreServer) hearthbeatPulsor(ctx context.Context, interval time.Duratio
 
 func (s *CoreServer) hearthbeatSub(msg *mir.Msg, deviceId string) {
 	l.Trace().Str("route", "hearthbeat").Msg("hearthbeat device request")
+	degradedMode := false
 	// If not in map, mean is newly online device
 	timeNow := time.Now().UTC()
 	// if last != now by >= 3 mins, the device offline
@@ -366,42 +370,44 @@ func (s *CoreServer) hearthbeatSub(msg *mir.Msg, deviceId string) {
 		LastHearthbeat: &surrealdbModels.CustomDateTime{Time: timeNow},
 	})
 
-	dev, err := s.store.UpdateDevice(t, d)
+	devs, err := s.store.UpdateDevice(t, d)
 	if err != nil {
 		if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 			l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
 		}
-		msg.Ack()
-		return
+		// Degraded mode
+		degradedMode = true
+		devs = []mir_v1.Device{
+			mir_v1.NewDevice().WithId(deviceId).WithMeta(mir_v1.Meta{
+				Name:      deviceId,
+				Namespace: "__degraded",
+			}),
+		}
 	}
 	// Means device is not in db, we provision it
-	if len(dev) == 0 {
+	if len(devs) == 0 && !degradedMode {
 		_, err := s.m.Client().CreateDevice().Request(mir_v1.NewDevice().WithSpec(mir_v1.DeviceSpec{
 			DeviceId: deviceId,
 		}))
 		if err != nil {
 			l.Error().Err(err).Str("device_id", deviceId).Msg("could not automaticly provision new device")
-			msg.Ack()
-			return
 		}
-		dev, err = s.store.UpdateDevice(t, d)
+		devs, err = s.store.UpdateDevice(t, d)
 		if err != nil {
 			if !strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 				l.Error().Err(err).Msg("error occure while executing hearthbeat db query")
 			}
-			msg.Ack()
-			return
 		}
 		deviceStatusCount.WithLabelValues("offline").Inc()
 	}
 
-	if _, ok := s.hearthbeats[deviceId]; !ok && len(dev) > 0 {
+	if _, ok := s.hearthbeats[deviceId]; !ok && len(devs) > 0 {
 		l.Info().Str("route", "hearthbeat").Str("event", "device_online").Msg(deviceId)
-		if err := publishDeviceOnlineEvent(s.m, msg, dev[0]); err != nil {
+		if err := publishDeviceOnlineEvent(s.m, msg, devs[0]); err != nil {
 			l.Warn().Err(err).Str("device_id", deviceId).Msg("error occure while publishing device online event")
 		}
 		deviceStatusCount.WithLabelValues("online").Inc()
-		deviceStatusCount.WithLabelValues("offline").Sub(1)
+		deviceStatusCount.WithLabelValues("offline").Dec()
 	}
 	s.hearthbeatsMutex.Lock()
 	s.hearthbeats[deviceId] = time.Now().UTC()
@@ -444,21 +450,6 @@ func (s *CoreServer) schemaSub(msg *mir.Msg, deviceId string, sch *mir_proto.Mir
 	}
 
 	msg.Ack()
-}
-
-func sendReplyOrAck(bus *bus.BusConn, msg nats.Msg, m protoreflect.ProtoMessage) {
-	if msg.Reply != "" {
-		bResp, err := proto.Marshal(m)
-		if err != nil {
-			l.Error().Err(err).Msg("error occure while creating response")
-		}
-		err = bus.Publish(msg.Reply, bResp)
-		if err != nil {
-			l.Error().Err(err).Msg("error occure while sending reply")
-		}
-	} else {
-		msg.Ack()
-	}
 }
 
 func publishDeviceOnlineEvent(m *mir.Mir, msg *mir.Msg, d mir_v1.Device) error {

--- a/internal/servers/eventstore_srv/server.go
+++ b/internal/servers/eventstore_srv/server.go
@@ -177,7 +177,7 @@ func (s *EventStoreServer) streamEventsSub(msg *mir.Msg, subjectId string, req m
 	if req.RelatedObject.Meta.Name != "" {
 		event.Meta.Name = req.RelatedObject.Meta.Name + "-" + id.String()[24:]
 	} else {
-		event.Meta.Name = id.String()
+		event.Meta.Name = subjectId + "-" + id.String()[24:]
 	}
 	event.Meta.Namespace = req.RelatedObject.Meta.Namespace
 	if event.Meta.Namespace == "" {
@@ -235,7 +235,7 @@ func (s *EventStoreServer) sendToDb(event mir_v1.Event) error {
 
 func (s *EventStoreServer) dbConnUpdate(status external.ConnectionStatus) {
 	if s.store.Status() == external.StatusConnected {
-		l.Warn().Str("status", status.String()).Int("buffer count", len(s.eventsBuffer)).Msg("database reconnected: sending buffered events to storage")
+		l.Info().Str("status", status.String()).Int("buffer count", len(s.eventsBuffer)).Msg("database reconnected: sending buffered events to storage")
 		s.eventsFn = s.sendToDb
 
 		// If the db reconnect and then redisconnect while this is ongoing

--- a/internal/servers/eventstore_srv/server.go
+++ b/internal/servers/eventstore_srv/server.go
@@ -57,6 +57,11 @@ var (
 		Name:      "event_capture_error_total",
 		Help:      "Number of events captured by the system in error",
 	}, []string{"event"})
+	eventBufferSize = metrics.NewGauge(prometheus.GaugeOpts{
+		Subsystem: "eventstore",
+		Name:      "event_buffer_size",
+		Help:      "Number of events in buffer",
+	})
 
 	l zerolog.Logger
 )
@@ -213,13 +218,17 @@ func (s *EventStoreServer) sendToBuffer(event mir_v1.Event) error {
 	s.eventsBufferMu.Lock()
 	defer s.eventsBufferMu.Unlock()
 	s.eventsBuffer = append(s.eventsBuffer, event)
+	eventBufferSize.Inc()
 	return nil
 }
 
 func (s *EventStoreServer) sendToDb(event mir_v1.Event) error {
 	_, err := s.store.CreateEvent(event)
 	if err != nil {
+		s.eventsBufferMu.Lock()
 		s.eventsBuffer = append(s.eventsBuffer, event)
+		eventBufferSize.Inc()
+		s.eventsBufferMu.Unlock()
 	}
 	return err
 }
@@ -250,6 +259,7 @@ func (s *EventStoreServer) dbConnUpdate(status external.ConnectionStatus) {
 					s.eventsBufferMu.Unlock()
 					break
 				}
+				eventBufferSize.Dec()
 			}
 		}()
 	} else {

--- a/internal/servers/eventstore_srv/server.go
+++ b/internal/servers/eventstore_srv/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/maxthom/mir/internal/externals/mng"
 	"github.com/maxthom/mir/internal/libs/api/metrics"
+	"github.com/maxthom/mir/internal/libs/external"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	"github.com/maxthom/mir/pkgs/mir_v1"
 	"github.com/maxthom/mir/pkgs/module/mir"
@@ -20,12 +21,15 @@ import (
 )
 
 type EventStoreServer struct {
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-	wg        *sync.WaitGroup
-	m         *mir.Mir
-	store     mng.MirStore
-	schStore  *schema_cache.MirSchemaCache
+	ctx            context.Context
+	cancelCtx      context.CancelFunc
+	wg             *sync.WaitGroup
+	m              *mir.Mir
+	store          mng.MirStore
+	schStore       *schema_cache.MirSchemaCache
+	eventsBuffer   []mir_v1.Event
+	eventsBufferMu sync.RWMutex
+	eventsFn       func(event mir_v1.Event) error
 }
 
 const (
@@ -66,16 +70,39 @@ func NewEventStore(logger zerolog.Logger, m *mir.Mir, store mng.MirStore) (*Even
 	l = logger.With().Str("srv", "eventstore_server").Logger()
 	ctx, cancelFn := context.WithCancel(context.Background())
 	return &EventStoreServer{
-		ctx:       ctx,
-		cancelCtx: cancelFn,
-		wg:        &sync.WaitGroup{},
-		m:         m,
-		store:     store,
+		ctx:            ctx,
+		cancelCtx:      cancelFn,
+		wg:             &sync.WaitGroup{},
+		m:              m,
+		store:          store,
+		eventsBuffer:   []mir_v1.Event{},
+		eventsBufferMu: sync.RWMutex{},
 	}, nil
 }
 
 // Using the db and bus, listen for telemetry, deserialize using proto and push to line protocol db
 func (s *EventStoreServer) Serve() error {
+	// Set send function to buffer or db depending on db conn status
+	if s.store.Status() == external.StatusConnected {
+		s.eventsFn = s.sendToDb
+	} else {
+		l.Warn().Str("status", s.store.Status().String()).Msg("database disconnected: sending events to buffer")
+		s.eventsFn = s.sendToBuffer
+	}
+	s.wg.Add(1)
+	go func() {
+		ch := s.store.StatusSubscribe()
+		for {
+			select {
+			case status := <-ch:
+				s.dbConnUpdate(status)
+			case <-s.ctx.Done():
+				s.wg.Done()
+				return
+			}
+		}
+	}()
+
 	if err := s.m.Client().ListEvents().QueueSubscribe(ServiceName, s.listEventsSub); err != nil {
 		return err
 	}
@@ -173,12 +200,60 @@ func (s *EventStoreServer) streamEventsSub(msg *mir.Msg, subjectId string, req m
 	event.Status.FirstAt = &now
 	event.Status.LastAt = &now
 
-	_, err = s.store.CreateEvent(event)
-	if err != nil {
+	if err = s.eventsFn(event); err != nil {
 		eventCaptureErrorTotal.WithLabelValues(req.Reason).Inc()
 		l.Error().Err(err).Msg("error occure while streaming event")
 		return
 	}
 
-	l.Info().Msg("event streamed successfully")
+	l.Debug().Msg("event streamed successfully")
+}
+
+func (s *EventStoreServer) sendToBuffer(event mir_v1.Event) error {
+	s.eventsBufferMu.Lock()
+	defer s.eventsBufferMu.Unlock()
+	s.eventsBuffer = append(s.eventsBuffer, event)
+	return nil
+}
+
+func (s *EventStoreServer) sendToDb(event mir_v1.Event) error {
+	_, err := s.store.CreateEvent(event)
+	if err != nil {
+		s.eventsBuffer = append(s.eventsBuffer, event)
+	}
+	return err
+}
+
+func (s *EventStoreServer) dbConnUpdate(status external.ConnectionStatus) {
+	if s.store.Status() == external.StatusConnected {
+		l.Warn().Str("status", status.String()).Int("buffer count", len(s.eventsBuffer)).Msg("database reconnected: sending buffered events to storage")
+		s.eventsFn = s.sendToDb
+
+		// If the db reconnect and then redisconnect while this is ongoing
+		//   - We need to make sure not to lose the unprocess item so read them to the eventsBuffer > using second slice instead of inplace
+		//   - The process event can be relaunched a second time with a few events in the buffer, thus they
+		//     must not overwrite each other > mutex
+
+		go func() {
+			s.eventsBufferMu.Lock()
+			tempBuffer := make([]mir_v1.Event, len(s.eventsBuffer))
+			copy(tempBuffer, s.eventsBuffer)
+			s.eventsBuffer = []mir_v1.Event{}
+			s.eventsBufferMu.Unlock()
+
+			for i, evt := range tempBuffer {
+				if _, err := s.store.CreateEvent(evt); err != nil {
+					l.Error().Err(err).Msg("error sending event from buffer")
+					// Readd unprocessed item to the buffer
+					s.eventsBufferMu.Lock()
+					s.eventsBuffer = append(s.eventsBuffer, tempBuffer[i:]...)
+					s.eventsBufferMu.Unlock()
+					break
+				}
+			}
+		}()
+	} else {
+		l.Warn().Str("status", status.String()).Msg("database disconnected: sending events to buffer")
+		s.eventsFn = s.sendToBuffer
+	}
 }

--- a/internal/servers/protocmd_srv/server.go
+++ b/internal/servers/protocmd_srv/server.go
@@ -362,13 +362,14 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 	wg.Wait()
 
 	// Event
-	if !degradedMode {
-		if len(commandsToSend) > 0 {
-			for nameNs, cmdResp := range devResp {
-				nns := strings.Split(nameNs, "/")
-				if err = publishCommandEvent(s.m, msg, nns[0], nns[1], cmdResp); err != nil {
-					l.Warn().Err(err).Msg("error while publishing device command event")
-				}
+	if len(commandsToSend) > 0 {
+		for nameNs, cmdResp := range devResp {
+			nns := strings.Split(nameNs, "/")
+			if degradedMode {
+				nns = []string{nameNs, "__degraded"}
+			}
+			if err = publishCommandEvent(s.m, msg, nns[0], nns[1], cmdResp); err != nil {
+				l.Warn().Err(err).Msg("error while publishing device command event")
 			}
 		}
 	}

--- a/internal/ui/cli/event_cmd.go
+++ b/internal/ui/cli/event_cmd.go
@@ -167,20 +167,20 @@ func stringifyEvents(output string, events []mir_v1.Event) (string, error) {
 }
 
 func prettyStringEvents(events []mir_v1.Event) string {
-	format := "%-16s %-30s %-8s %-20s %-60s\n"
+	format := "%-16s %-45s %-8s %-20s %-60s\n"
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf(format, "AGE", "NAMESPACE/NAME", "TYPE", "REASON", "MESSAGE"))
 
-	// TODO sort namespace, time
+	// TODO sort time, namespace, name
 	sort.Slice(events, func(i, j int) bool {
-		if events[i].Meta.Namespace == events[j].Meta.Namespace {
-			if events[i].Status.FirstAt.Equal(events[j].Status.FirstAt.Time) {
+		if events[i].Status.FirstAt.Equal(events[j].Status.FirstAt.Time) {
+			if events[i].Meta.Namespace == events[j].Meta.Namespace {
 				return events[i].Meta.Name < events[j].Meta.Name
 			} else {
-				return events[i].Status.FirstAt.After(events[j].Status.FirstAt.Time)
+				return events[i].Meta.Namespace < events[j].Meta.Namespace
 			}
 		} else {
-			return events[i].Meta.Namespace < events[j].Meta.Namespace
+			return events[i].Status.FirstAt.After(events[j].Status.FirstAt.Time)
 		}
 	})
 

--- a/pkgs/device/mir/mir.go
+++ b/pkgs/device/mir/mir.go
@@ -245,7 +245,8 @@ func (m *Mir) Launch(ctx context.Context, opts ...nats.Option) (*sync.WaitGroup,
 
 	wg.Add(1)
 	go func() {
-		m.shutdown(m.ctx)
+		<-ctx.Done()
+		m.shutdown()
 		wg.Done()
 	}()
 
@@ -324,8 +325,7 @@ func (m *Mir) commands(ctx context.Context, sub *nats.Subscription) {
 	}
 }
 
-func (m *Mir) shutdown(ctx context.Context) {
-	<-ctx.Done()
+func (m *Mir) shutdown() {
 	m.l.Info().Msg("shutting down connection to Mir")
 	m.b.Conn.Close()
 }


### PR DESCRIPTION
Implement resilient event storage with automatic buffering when SurrealDB is disconnected. Events are queued in memory and flushed when connection is restored, preventing data loss during network interruptions.

- Add connection status monitoring and subscription mechanism
- Buffer events during database disconnection
- Auto-flush buffered events on reconnection
- Move ConnectionStatus to shared external package
- Update TASKS.md to reorganize production roadmap items

🤖 Generated with Claude Code (https://claude.com/claude-code)

<!-- Brief description of the changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Testing Done
<!-- Describe the testing you've done -->
- [ ] Manual tests
- [ ] Automated tests added
- [ ] No tests required

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues here using #issue-number -->
Closes #
