### PR TITLE
Refactored device creation API to separate single and bulk operations

### DIFF
--- a/.tmux/mir-test.session.sh
+++ b/.tmux/mir-test.session.sh
@@ -1,0 +1,27 @@
+# Set a custom session root path. Default is `$HOME`.
+# Must be called before `initialize_session`.
+session_root "$PWD"
+
+# Create session with specified name if it does not already exist. If no
+# argument is given, session name will be based on layout file name.
+if initialize_session "mir"; then
+
+	# Create a new window inline within session layout definition.
+	#new_window "misc"
+
+	# Load a defined window layout.
+	load_window "./.tmux/mir.window.sh"
+	load_window "./.tmux/claude.window.sh"
+	load_window "./.tmux/test.window.sh"
+	load_window "./.tmux/infra.window.sh"
+	load_window "./.tmux/cfg.window.sh"
+	load_window "./.tmux/book.window.sh"
+	load_window "./.tmux/wiki.window.sh"
+
+	# Select the default active window on session creation.
+	select_window 1
+
+fi
+
+# Finalize session creation and switch/attach to it.
+finalize_and_go_to_session

--- a/.tmux/test.window.sh
+++ b/.tmux/test.window.sh
@@ -1,0 +1,24 @@
+# Set window root path. Default is `$session_root`.
+# Must be called before `new_window`.
+window_root "$PWD"
+
+# Create new window. If no argument is given, window name will be based on
+# layout file name.
+new_window "test"
+
+# Split window into panes.
+split_v 20
+
+# Run commands.
+#run_cmd "top"     # runs in active pane
+#run_cmd  "~/code/zed/target/release/Zed" #"nvim ." 1 # runs in pane 1
+run_cmd "sleep 5" 1
+run_cmd "just test-infra" 1
+
+# Paste text
+#send_keys "top"    # paste into active pane
+#send_keys "date" 1 # paste into pane 1
+send_keys "cat .tmp/core.log" 2
+
+# Set active pane.
+select_pane 1

--- a/internal/clients/core_client/client.go
+++ b/internal/clients/core_client/client.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	CreateDeviceRequest clients.ClientSubject = "client.%s.core.v1alpha.create"
-	UpdateDeviceRequest clients.ClientSubject = "client.%s.core.v1alpha.update"
-	DeleteDeviceRequest clients.ClientSubject = "client.%s.core.v1alpha.delete"
-	ListDeviceRequest   clients.ClientSubject = "client.%s.core.v1alpha.list"
+	CreateDeviceRequest  clients.ClientSubject = "client.%s.core.v1alpha.create"
+	CreateDevicesRequest clients.ClientSubject = "client.%s.core.v1alpha.creates"
+	UpdateDeviceRequest  clients.ClientSubject = "client.%s.core.v1alpha.update"
+	DeleteDeviceRequest  clients.ClientSubject = "client.%s.core.v1alpha.delete"
+	ListDeviceRequest    clients.ClientSubject = "client.%s.core.v1alpha.list"
 
 	DeviceOnlineEvent  clients.ClientSubject = "event.%s.core.v1alpha.deviceonline"
 	DeviceOfflineEvent clients.ClientSubject = "event.%s.core.v1alpha.deviceoffline"
@@ -46,6 +47,26 @@ func PublishDeviceCreateRequest(bus *nats.Conn, req *mir_apiv1.CreateDeviceReque
 	err = proto.Unmarshal(resMsg.Data, resp)
 	if err != nil {
 		return &mir_apiv1.CreateDeviceResponse{}, err
+	}
+
+	return resp, nil
+}
+
+func PublishDevicesCreateRequest(bus *nats.Conn, req *mir_apiv1.CreateDevicesRequest) (*mir_apiv1.CreateDevicesResponse, error) {
+	bReq, err := proto.Marshal(req)
+	if err != nil {
+		return &mir_apiv1.CreateDevicesResponse{}, err
+	}
+
+	resMsg, err := bus.Request(CreateDevicesRequest.WithId("todo"), bReq, 7*time.Second)
+	if err != nil {
+		return &mir_apiv1.CreateDevicesResponse{}, err
+	}
+
+	resp := &mir_apiv1.CreateDevicesResponse{}
+	err = proto.Unmarshal(resMsg.Data, resp)
+	if err != nil {
+		return &mir_apiv1.CreateDevicesResponse{}, err
 	}
 
 	return resp, nil

--- a/internal/externals/mng/devices.go
+++ b/internal/externals/mng/devices.go
@@ -105,10 +105,8 @@ func (s *surrealMirStore) CreateDevices(devs []mir_v1.Device) ([]mir_v1.Device, 
 		}
 	}
 	devs = uniqueDevs
-
-	if len(devs) == 1 {
-		resp, err := s.CreateDevice(devs[0])
-		return []mir_v1.Device{resp}, errors.Join(errs, err)
+	if errs != nil {
+		return []mir_v1.Device{}, errs
 	}
 
 	// Check duplicates already in database
@@ -152,7 +150,7 @@ func (s *surrealMirStore) CreateDevices(devs []mir_v1.Device) ([]mir_v1.Device, 
 	if err != nil {
 		return []mir_v1.Device{}, fmt.Errorf("%w: %w", mir_v1.ErrorDbExecutingQuery, err)
 	}
-	return *respDb, errs
+	return *respDb, nil
 }
 
 // UpdateDevice This method is too OP

--- a/internal/externals/mng/store_integration_test.go
+++ b/internal/externals/mng/store_integration_test.go
@@ -125,6 +125,54 @@ func TestPublishStoreDeviceCreateMany(t *testing.T) {
 	assert.Equal(t, len(dResp), count)
 }
 
+func TestPublishStoreDeviceCreateOne(t *testing.T) {
+	// Arrange
+	d := mir_v1.NewDevice().WithMeta(mir_v1.Meta{
+		Name:      "create_dev_one",
+		Namespace: "mirstore",
+		Labels: map[string]string{
+			"mirstore": "testing",
+		},
+	}).WithSpec(mir_v1.DeviceSpec{
+		DeviceId: "create_dev_one",
+		Disabled: boolPtr(true),
+	})
+
+	// Act
+	dResp, err := mirStore.CreateDevice(d)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Assert
+	assert.Equal(t, dResp.Spec.DeviceId, d.Spec.DeviceId)
+}
+
+func TestPublishStoreDeviceCreateAlreadyExist(t *testing.T) {
+	// Arrange
+	id := "create_dev_one_already"
+	d := mir_v1.NewDevice().WithMeta(mir_v1.Meta{
+		Name:      id,
+		Namespace: "mirstore",
+		Labels: map[string]string{
+			"mirstore": "testing",
+		},
+	}).WithSpec(mir_v1.DeviceSpec{
+		DeviceId: id,
+		Disabled: boolPtr(true),
+	})
+
+	// Act
+	_, err := mirStore.CreateDevice(d)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = mirStore.CreateDevice(d)
+
+	// Assert
+	assert.ErrorContains(t, err, "device create_dev_one_already/mirstore with deviceId create_dev_one_already already exist")
+}
+
 func TestPublishStoreDeviceCreateManyAlreadyExist(t *testing.T) {
 	// Arrange
 	devs := []mir_v1.Device{}
@@ -290,16 +338,7 @@ func TestPublishStoreDeviceCreateManyDuplicate(t *testing.T) {
 	}
 
 	// Assert
-	assert.Equal(t, len(dResp), 7)
-	seen := make(map[string]bool)
-	for _, d := range dResp {
-		deviceIdKey := d.Spec.DeviceId
-		nameNsKey := d.Meta.Name + "/" + d.Meta.Namespace
-		// Check that we have not seen this deviceId or name/namespace before
-		assert.Assert(t, true, !seen[deviceIdKey] && !seen[nameNsKey])
-		seen[deviceIdKey] = true
-		seen[nameNsKey] = true
-	}
+	assert.Equal(t, len(dResp), 0)
 }
 
 func TestPublishStoreDeviceCreateMissingNameNamespace(t *testing.T) {

--- a/internal/libs/swarm/swarm.go
+++ b/internal/libs/swarm/swarm.go
@@ -109,7 +109,7 @@ type devicesBuilder struct {
 	tlsCert     string
 	caCert      string
 	logWriters  []io.Writer
-	deviceReqs  []*mir_apiv1.CreateDeviceRequest_Device
+	deviceReqs  []*mir_apiv1.NewDevice
 	deviceIds   []string
 	sch         []protoreflect.FileDescriptor
 	schProto    []*descriptorpb.FileDescriptorProto
@@ -126,7 +126,7 @@ type deviceBuilder struct {
 	caCert      string
 	logLevel    mirDevice.LogLevel
 	logWriters  []io.Writer
-	deviceReq   *mir_apiv1.CreateDeviceRequest_Device
+	deviceReq   *mir_apiv1.NewDevice
 	sch         []protoreflect.FileDescriptor
 	schProto    []*descriptorpb.FileDescriptorProto
 	cmd         []commandHandler
@@ -153,7 +153,7 @@ func (s *Swarm) AddDeviceWithIds(ids []string) *devicesBuilder {
 		},
 	}
 }
-func (s *Swarm) AddDevices(req ...*mir_apiv1.CreateDeviceRequest_Device) *devicesBuilder {
+func (s *Swarm) AddDevices(req ...*mir_apiv1.NewDevice) *devicesBuilder {
 	return &devicesBuilder{
 		deviceReqs: req,
 		s:          s,
@@ -164,7 +164,7 @@ func (s *Swarm) AddDevices(req ...*mir_apiv1.CreateDeviceRequest_Device) *device
 	}
 }
 
-func (s *Swarm) AddDevice(req *mir_apiv1.CreateDeviceRequest_Device) *deviceBuilder {
+func (s *Swarm) AddDevice(req *mir_apiv1.NewDevice) *deviceBuilder {
 	return &deviceBuilder{
 		deviceReq: req,
 		s:         s,
@@ -288,8 +288,8 @@ func (b *devicesBuilder) Incubate() ([]mir_v1.Device, error) {
 		b.s.Devices = append(b.s.Devices, dev)
 	}
 
-	resp, err := core_client.PublishDeviceCreateRequest(b.s.bus,
-		&mir_apiv1.CreateDeviceRequest{
+	resp, err := core_client.PublishDevicesCreateRequest(b.s.bus,
+		&mir_apiv1.CreateDevicesRequest{
 			Devices: b.deviceReqs,
 		})
 	if err != nil {
@@ -391,7 +391,7 @@ func (b *deviceBuilder) Incubate() (mir_v1.Device, error) {
 
 	resp, err := core_client.PublishDeviceCreateRequest(b.s.bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{b.deviceReq},
+			Device: b.deviceReq,
 		})
 	if err != nil {
 		return mir_v1.Device{}, err
@@ -399,8 +399,8 @@ func (b *deviceBuilder) Incubate() (mir_v1.Device, error) {
 	if resp.GetError() != "" {
 		return mir_v1.Device{}, errors.New(resp.GetError())
 	}
-	if resp.GetOk() == nil || len(resp.GetOk().Devices) == 0 {
+	if resp.GetOk() == nil {
 		return mir_v1.Device{}, nil
 	}
-	return mir_v1.NewDeviceListFromProtoDevices(resp.GetOk().Devices)[0], nil
+	return mir_v1.NewDeviceFromProtoDevice(resp.GetOk()), nil
 }

--- a/internal/libs/test_utils/test_utils.go
+++ b/internal/libs/test_utils/test_utils.go
@@ -90,18 +90,32 @@ func DeleteDevicesWithLabelsPanic(b *nats.Conn, lbl map[string]string) {
 	}
 }
 
-func CreateDevices(bus *nats.Conn, devices []*mir_apiv1.CreateDeviceRequest_Device) ([]*mir_apiv1.Device, error) {
-	resp, err := core_client.PublishDeviceCreateRequest(bus,
-		&mir_apiv1.CreateDeviceRequest{
+func CreateDevices(bus *nats.Conn, devices []*mir_apiv1.NewDevice) ([]*mir_apiv1.Device, error) {
+	resp, err := core_client.PublishDevicesCreateRequest(bus,
+		&mir_apiv1.CreateDevicesRequest{
 			Devices: devices,
 		})
 	if err != nil {
 		return nil, err
 	}
 	if resp.GetError() != "" {
-		err = errors.New(resp.GetError())
+		return nil, errors.New(resp.GetError())
 	}
-	return resp.GetOk().Devices, err
+	return resp.GetOk().Devices, nil
+}
+
+func CreateDevice(bus *nats.Conn, device *mir_apiv1.NewDevice) (*mir_apiv1.Device, error) {
+	resp, err := core_client.PublishDeviceCreateRequest(bus,
+		&mir_apiv1.CreateDeviceRequest{
+			Device: device,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if resp.GetError() != "" {
+		return nil, errors.New(resp.GetError())
+	}
+	return resp.GetOk(), nil
 }
 
 func ExecuteTestQueryForType[T any](t *testing.T, db *surreal.AutoReconnDB, query string, vars map[string]any) T {

--- a/internal/servers/core_srv/server.go
+++ b/internal/servers/core_srv/server.go
@@ -160,6 +160,9 @@ func (s *CoreServer) Serve() error {
 	if err := s.m.Client().CreateDevice().QueueSubscribe(ServiceName, s.createDeviceSub); err != nil {
 		return err
 	}
+	if err := s.m.Client().CreateDevices().QueueSubscribe(ServiceName, s.createDevicesSub); err != nil {
+		return err
+	}
 	if err := s.m.Client().UpdateDevice().QueueSubscribe(ServiceName, s.updateDeviceSub); err != nil {
 		return err
 	}
@@ -204,14 +207,33 @@ func (s *CoreServer) Shutdown() error {
 	return nil
 }
 
-func (s *CoreServer) createDeviceSub(msg *mir.Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error) {
+func (s *CoreServer) createDeviceSub(msg *mir.Msg, clientId string, d mir_v1.Device) (mir_v1.Device, error) {
 	l.Debug().Str("route", "create").Str("payload", fmt.Sprintf("%v", d)).Msg("new device request")
+	requestTotal.WithLabelValues("create").Inc()
+
+	newDev, err := s.store.CreateDevice(d)
+	if err != nil {
+		l.Error().Err(err).Msg("error occure while creating device")
+		requestErrorTotal.WithLabelValues("create").Inc()
+	}
+
+	// Publish created events
+	if err := publishDeviceCreateEvent(s.m, msg, newDev); err != nil {
+		l.Warn().Err(err).Str("device_id", newDev.Spec.DeviceId).Msg("error occure while publishing device created event")
+	}
+
+	return newDev, err
+}
+
+func (s *CoreServer) createDevicesSub(msg *mir.Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error) {
+	l.Debug().Str("route", "create").Str("payload", fmt.Sprintf("%v", d)).Msg("new devices request")
 	requestTotal.WithLabelValues("create").Inc()
 
 	newDevs, err := s.store.CreateDevices(d)
 	if err != nil {
-		l.Error().Err(err).Msg("error occure while creating some devices")
+		l.Error().Err(err).Msg("error occure while creating devices")
 		requestErrorTotal.WithLabelValues("create").Inc()
+		return nil, fmt.Errorf("error creating devices: %w", err)
 	}
 
 	// Publish created events
@@ -443,7 +465,7 @@ func (s *CoreServer) hearthbeatOnlinePulsor() {
 			}))
 			newDevsId = append(newDevsId, string(id))
 		}
-		_, err := s.m.Client().CreateDevice().RequestMany(newDevs)
+		_, err := s.m.Client().CreateDevices().Request(newDevs)
 		if err != nil {
 			l.Error().Err(err).Strs("device_ids", newDevsId).Msg("could not automaticly provision new devices")
 		}

--- a/internal/servers/core_srv/server_integration_test.go
+++ b/internal/servers/core_srv/server_integration_test.go
@@ -84,7 +84,7 @@ func TestPublishDeviceCreate(t *testing.T) {
 	id := "device_create_raw"
 	publishStream := "client." + id + ".core.v1alpha.create"
 	reqCreate := &mir_apiv1.CreateDeviceRequest{
-		Devices: []*mir_apiv1.CreateDeviceRequest_Device{{
+		Device: &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      id,
 				Namespace: "testing_core",
@@ -101,7 +101,7 @@ func TestPublishDeviceCreate(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: id,
 			},
-		}},
+		},
 	}
 
 	// Act
@@ -127,13 +127,13 @@ func TestPublishDeviceCreate(t *testing.T) {
 	}
 
 	// Assert
-	assert.Equal(t, reqCreate.Devices[0].Spec.DeviceId, respList.GetOk().Devices[0].Spec.DeviceId)
+	assert.Equal(t, reqCreate.Device.Spec.DeviceId, respList.GetOk().Devices[0].Spec.DeviceId)
 }
 
 func TestPublishDeviceCreateClient(t *testing.T) {
 	// Arrange
 	id := "device_create"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -164,10 +164,13 @@ func TestPublishDeviceCreateClient(t *testing.T) {
 	// Act
 	respCreate, err := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
+	}
+	if respCreate.GetError() != "" {
+		t.Error(respCreate.GetError())
 	}
 	time.Sleep(1 * time.Second)
 
@@ -179,10 +182,13 @@ func TestPublishDeviceCreateClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	if respList.GetError() != "" {
+		t.Error(respList.GetError())
+	}
 
 	// Assert
 	assert.Equal(t, reqCreate.Spec.DeviceId, respList.GetOk().Devices[0].Spec.DeviceId)
-	assert.Equal(t, respCreate.GetOk().Devices[0].Spec.DeviceId, respList.GetOk().Devices[0].Spec.DeviceId)
+	assert.Equal(t, respCreate.GetOk().Spec.DeviceId, respList.GetOk().Devices[0].Spec.DeviceId)
 	assert.Equal(t, 1, count)
 	s.Unsubscribe()
 }
@@ -190,7 +196,7 @@ func TestPublishDeviceCreateClient(t *testing.T) {
 func TestPublishDeviceCreateClientNoID(t *testing.T) {
 	// Arrange
 	id := ""
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -212,18 +218,18 @@ func TestPublishDeviceCreateClientNoID(t *testing.T) {
 	// Act
 	resp, _ := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 
 	// Assert
 	assert.Equal(t, resp.GetError() != "", true)
-	assert.Equal(t, resp.GetError(), "device at index 0 is missing its id")
+	assert.Equal(t, resp.GetError(), "device id is missing")
 }
 
 func TestPublishDeviceCreateClientNoNamespace(t *testing.T) {
 	// Arrange
 	id := "create_dev_no_namespace"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "",
@@ -241,21 +247,24 @@ func TestPublishDeviceCreateClientNoNamespace(t *testing.T) {
 	// Act
 	respCreate, err := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
 	}
+	if respCreate.GetError() != "" {
+		t.Error(respCreate.GetError())
+	}
 
 	// Assert
-	assert.Equal(t, reqCreate.Spec.DeviceId, respCreate.GetOk().Devices[0].Spec.DeviceId)
-	assert.Equal(t, respCreate.GetOk().Devices[0].Meta.Namespace, "default")
+	assert.Equal(t, reqCreate.Spec.DeviceId, respCreate.GetOk().Spec.DeviceId)
+	assert.Equal(t, respCreate.GetOk().Meta.Namespace, "default")
 }
 
 func TestPublishDeviceUpdateTargetIds(t *testing.T) {
 	// Arrange
 	id := "device_update_target_ids"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -317,7 +326,7 @@ func TestPublishDeviceUpdateTargetIds(t *testing.T) {
 	// Act
 	if _, err := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		}); err != nil {
 		t.Error(err)
 	}
@@ -347,7 +356,7 @@ func TestPublishDeviceUpdateTargetIds(t *testing.T) {
 func TestPublishDeviceUpdateTargetNames(t *testing.T) {
 	// Arrange
 	id := "device_update_target_names"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -400,7 +409,7 @@ func TestPublishDeviceUpdateTargetNames(t *testing.T) {
 	// Act
 	if _, err := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		}); err != nil {
 		t.Error(err)
 	}
@@ -428,7 +437,7 @@ func TestPublishDeviceUpdateTargetNamespace(t *testing.T) {
 	// Arrange
 	id := "device_update_target_namespace"
 	ns := "testing_" + id
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: ns,
@@ -481,7 +490,7 @@ func TestPublishDeviceUpdateTargetNamespace(t *testing.T) {
 	// Act
 	if _, err := core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		}); err != nil {
 		t.Error(err)
 	}
@@ -538,7 +547,7 @@ func TestPublishDeviceUpdateTargetLabels(t *testing.T) {
 			},
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -671,7 +680,7 @@ func TestPublishDeviceUpdateTargetMixs(t *testing.T) {
 			},
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -783,7 +792,7 @@ func TestPublishDeviceDeleteTargetIds(t *testing.T) {
 			Ids: []string{deviceIds[0], deviceIds[1]},
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -895,7 +904,7 @@ func TestPublishDeviceDeleteTargetNames(t *testing.T) {
 			Names: []string{deviceIds[0], deviceIds[1]},
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -997,7 +1006,7 @@ func TestPublishDeviceDeleteTargetNamespace(t *testing.T) {
 			Namespaces: []string{ns},
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1099,7 +1108,7 @@ func TestPublishDeviceDeleteTargetLabels(t *testing.T) {
 	}
 
 	deviceIds := []string{"device_delete_target_lbls_1", "device_delete_target_lbls_2", "device_delete_target_lbls_3"}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1196,7 +1205,7 @@ func TestPublishDeviceListTargetIds(t *testing.T) {
 		},
 	}
 
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1296,7 +1305,7 @@ func TestPublishDeviceListTargetNames(t *testing.T) {
 		},
 	}
 
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1397,7 +1406,7 @@ func TestPublishDeviceListTargetNamespace(t *testing.T) {
 		},
 	}
 
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1500,7 +1509,7 @@ func TestPublishDeviceListTargetLabels(t *testing.T) {
 	}
 
 	deviceIds := []string{"device_list_target_lbls_1", "device_list_target_lbls_2", "device_list_target_lbls_3"}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1598,7 +1607,7 @@ func TestPublishDeviceListNoTarget(t *testing.T) {
 	}
 
 	deviceIds := []string{"device_list_target_no_1", "device_list_target_no_2", "device_list_target_no_3"}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1680,7 +1689,7 @@ func TestPublishDeviceListNoTarget(t *testing.T) {
 func TestCreatedDeviceAlreadyExist(t *testing.T) {
 	// Arrange
 	deviceIds := []string{"device_already_exist_1", "device_already_exist_1"}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -1735,14 +1744,17 @@ func TestCreatedDeviceAlreadyExist(t *testing.T) {
 		})
 
 	// Act
-	respCreate, err := test_utils.CreateDevices(mSdk.Bus, reqCreate)
+	_, err := test_utils.CreateDevice(mSdk.Bus, reqCreate[0])
 	if err != nil {
-		assert.ErrorContains(t, err, "device with id device_already_exist_1 is duplicated")
+		t.Error(err)
 	}
 	time.Sleep(1 * time.Second)
+	_, err = test_utils.CreateDevice(mSdk.Bus, reqCreate[1])
+	if err != nil {
+		assert.ErrorContains(t, err, "device device_already_exist_1/testing_core with deviceId device_already_exist_1 already exist")
+	}
 
 	// Assert
-	assert.Equal(t, len(respCreate), 1)
 	assert.Equal(t, 1, count) // We create two devices, so only second one is not working
 	s.Unsubscribe()
 }
@@ -1780,7 +1792,7 @@ func TestDeleteNoTargetMetafield(t *testing.T) {
 func TestDeviceCreateDeviceIdAlreadyExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	build := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	build := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "create_dev_same_id_1",
 			Namespace: "testing_core",
@@ -1792,7 +1804,7 @@ func TestDeviceCreateDeviceIdAlreadyExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86cmd",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "create_dev_same_id_2",
 			Namespace: "testing_core",
@@ -1819,7 +1831,7 @@ func TestDeviceCreateDeviceIdAlreadyExist(t *testing.T) {
 func TestDeviceCreateDeviceNameNsAlreadyExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	build := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	build := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "create_dev_same_id_3",
 			Namespace: "testing_core",
@@ -1831,7 +1843,7 @@ func TestDeviceCreateDeviceNameNsAlreadyExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "create_dev_same_id_3",
 			Namespace: "testing_core",
@@ -1901,7 +1913,7 @@ func TestDeviceUpsertDevice(t *testing.T) {
 func TestDeviceUpdateManyTargetSameDeviceId(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_sameid_1",
 			Namespace: "testing_core",
@@ -1913,7 +1925,7 @@ func TestDeviceUpdateManyTargetSameDeviceId(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm24",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_sameid_2",
 			Namespace: "testing_core",
@@ -1955,7 +1967,7 @@ func TestDeviceUpdateManyTargetSameDeviceId(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNameNoExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_samename_noexist_1",
 			Namespace: "testing_core",
@@ -1967,7 +1979,7 @@ func TestDeviceUpdateManyTargetSameNameNoExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm21",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_samename_noexist_2",
 			Namespace: "testing_core",
@@ -2008,7 +2020,7 @@ func TestDeviceUpdateManyTargetSameNameNoExist(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNameOneExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_samename_oneexist",
 			Namespace: "testing_core",
@@ -2020,7 +2032,7 @@ func TestDeviceUpdateManyTargetSameNameOneExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm17",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "samebloodyname",
 			Namespace: "testing_core",
@@ -2061,7 +2073,7 @@ func TestDeviceUpdateManyTargetSameNameOneExist(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNamespaceNoExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_ns_no_exist",
 			Namespace: "testing_core",
@@ -2073,7 +2085,7 @@ func TestDeviceUpdateManyTargetSameNamespaceNoExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm12",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_ns_no_exist",
 			Namespace: "testing_core_2",
@@ -2114,7 +2126,7 @@ func TestDeviceUpdateManyTargetSameNamespaceNoExist(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNamespaceOneExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_ns_one_exist",
 			Namespace: "samebloodynamespace",
@@ -2125,7 +2137,7 @@ func TestDeviceUpdateManyTargetSameNamespaceOneExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm7",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_ns_one_exist",
 			Namespace: "testing_core_2",
@@ -2166,7 +2178,7 @@ func TestDeviceUpdateManyTargetSameNamespaceOneExist(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNameNamespaceNoExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "samebloodyname",
 			Namespace: "samebloodynamespace",
@@ -2178,7 +2190,7 @@ func TestDeviceUpdateManyTargetSameNameNamespaceNoExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm14",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_same_namens_2",
 			Namespace: "testing_core_2",
@@ -2220,7 +2232,7 @@ func TestDeviceUpdateManyTargetSameNameNamespaceNoExist(t *testing.T) {
 func TestDeviceUpdateManyTargetSameNameNamespaceOneExist(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
-	sb := s.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	sb := s.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_same_namens_one_1",
 			Namespace: "testing_core",
@@ -2232,7 +2244,7 @@ func TestDeviceUpdateManyTargetSameNameNamespaceOneExist(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "0xf86tlm15",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "update_dev_same_namens_one_2",
 			Namespace: "testing_core_2",
@@ -2279,7 +2291,7 @@ func TestDeviceGoesOnline(t *testing.T) {
 			Ids: deviceIds,
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -2348,7 +2360,7 @@ func TestDeviceGoesOffline(t *testing.T) {
 			Ids: deviceIds,
 		},
 	}
-	reqCreate := []*mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := []*mir_apiv1.NewDevice{
 		{
 			Meta: &mir_apiv1.Meta{
 				Name:      deviceIds[0],
@@ -2582,7 +2594,7 @@ func TestDeviceUpdateDesiredProperties(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
 	id := "update_desired_props"
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -2646,7 +2658,7 @@ func TestDeviceUpdateDesiredPropertiesDoubleSameUpdate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
 	id := "update_desired_props_double"
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -2714,7 +2726,7 @@ func TestDeviceUpdateDesiredPropertiesInvalid(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
 	id := "update_desired_props_invalid"
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",

--- a/internal/servers/eventstore_srv/server_integration_test.go
+++ b/internal/servers/eventstore_srv/server_integration_test.go
@@ -220,7 +220,7 @@ func TestPublishListDeviceRequestWithEvents(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
-	_, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	_, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "event_testing",
 		},

--- a/internal/servers/protocfg_srv/server_integration_test.go
+++ b/internal/servers/protocfg_srv/server_integration_test.go
@@ -76,7 +76,7 @@ func TestPublishCfgListRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_list_cfg"
 	s := swarm.NewSwarm(mSdk.Bus)
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -137,7 +137,7 @@ func TestPublishCfgListFiltersRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_list_cfg_filters"
 	s := swarm.NewSwarm(mSdk.Bus)
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -194,7 +194,7 @@ func TestPublishCfgRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -248,7 +248,7 @@ func TestPublishCfgRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -313,7 +313,7 @@ func TestPublishCfgJsonRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_json"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -366,7 +366,7 @@ func TestPublishCfgJsonRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -412,7 +412,7 @@ func TestPublishCfgCurrentValues(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_current_values"
 	nameNs := id + "/testing_cfg"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -474,7 +474,7 @@ func TestPublishCfgCurrentValues(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -538,7 +538,7 @@ func TestPublishCfgRequestCheckTime(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_time"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -597,7 +597,7 @@ func TestPublishCfgRequestCheckTime(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -654,7 +654,7 @@ func TestPublishCfgDoubleUpdateSendIfDifferent(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_json"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -720,7 +720,7 @@ func TestPublishCfgDoubleUpdateSendIfDifferent(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -774,7 +774,7 @@ func TestPublishCfgDoubleUpdateSendAlways(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_json"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -840,7 +840,7 @@ func TestPublishCfgDoubleUpdateSendAlways(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -895,7 +895,7 @@ func TestPublishCfgDoubleUpdateIsDifferent(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_json"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -969,7 +969,7 @@ func TestPublishCfgDoubleUpdateIsDifferent(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -1055,7 +1055,7 @@ func TestPublishCfgProtoDryRun(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "proto_dryrun_cfg"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -1099,7 +1099,7 @@ func TestPublishCfgProtoDryRun(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -1132,7 +1132,7 @@ func TestPublishCfgProtoInvalidPayload(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_invalid_payload"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -1189,7 +1189,7 @@ func TestPublishCfgProtoInvalidPayload(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -1223,7 +1223,7 @@ func TestPublishCfgRequestMultipleDevices(t *testing.T) {
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
 	chHdlr := make(chan struct{}, 4)
-	_, err := swarm.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	_, err := swarm.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "testing_cfg",
 			Labels: map[string]string{
@@ -1236,7 +1236,7 @@ func TestPublishCfgRequestMultipleDevices(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "device_send_cfg_1",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "testing_cfg",
 			Labels: map[string]string{
@@ -1317,7 +1317,7 @@ func TestPublishCfgRequestMultipleDevicesOneNoHandler(t *testing.T) {
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
 	chHdlr := make(chan struct{}, 4)
-	if _, err := swarm.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := swarm.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "testing_cfg",
 			Labels: map[string]string{
@@ -1330,7 +1330,7 @@ func TestPublishCfgRequestMultipleDevicesOneNoHandler(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "device_send_cfg_1_no_handler",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "testing_cfg",
 			Labels: map[string]string{
@@ -1355,7 +1355,7 @@ func TestPublishCfgRequestMultipleDevicesOneNoHandler(t *testing.T) {
 		).Incubate(); err != nil {
 		t.Error(err)
 	}
-	if _, err := swarm.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := swarm.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Namespace: "testing_cfg",
 			Labels: map[string]string{
@@ -1436,7 +1436,7 @@ func TestPublishCfgRequestMultipleDevicesJson(t *testing.T) {
 	handlerCount := 0
 	chHdlr := make(chan struct{}, 4)
 	_, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1446,7 +1446,7 @@ func TestPublishCfgRequestMultipleDevicesJson(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_send_cfg_multi_json_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1525,7 +1525,7 @@ func TestPublishCfgRequestMultipleDevicesDescriptorNotFound(t *testing.T) {
 	handlerCount := 0
 	chHdlr := make(chan struct{}, 2)
 	_, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1535,7 +1535,7 @@ func TestPublishCfgRequestMultipleDevicesDescriptorNotFound(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_cfg_send_notfound_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1605,7 +1605,7 @@ func TestPublishCfgRequestMultipleDevicesSingleDescriptorNotFoundForcePush(t *te
 	handlerCount := 0
 	chHdlr := make(chan struct{}, 2)
 	_, err := swarm.AddDevice(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1626,7 +1626,7 @@ func TestPublishCfgRequestMultipleDevicesSingleDescriptorNotFoundForcePush(t *te
 			},
 		).Incubate()
 	_, err = swarm.AddDevice(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1701,7 +1701,7 @@ func TestPublishCfgRequestMultipleDevicesJsonTemplate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	respD, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1714,7 +1714,7 @@ func TestPublishCfgRequestMultipleDevicesJsonTemplate(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_send_cfg_multi_json_tlm_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cfg",
 				Labels: map[string]string{
@@ -1771,7 +1771,7 @@ func TestPublishCfgRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_multi_timeout_json_template_1"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -1795,7 +1795,7 @@ func TestPublishCfgRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	}
 
 	id2 := "device_send_cfg_multi_timeout_json_template_2"
-	reqCreate2 := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate2 := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id2,
 			Namespace: "testing_cfg",
@@ -1824,14 +1824,14 @@ func TestPublishCfgRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
 	}
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate2},
+			Device: reqCreate2,
 		})
 	if err != nil {
 		t.Error(err)
@@ -1870,7 +1870,7 @@ func TestPublishCfgJsonNameWithCurlyRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_json_curly"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -1923,7 +1923,7 @@ func TestPublishCfgJsonNameWithCurlyRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -2068,7 +2068,7 @@ func TestPublishDesiredPropertiesEvent(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cfg_event"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -2133,7 +2133,7 @@ func TestPublishDesiredPropertiesEvent(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -2177,7 +2177,7 @@ func TestDesiredPropertiesDefaultWritten(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_request_desired_props_default"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -2209,7 +2209,7 @@ func TestDesiredPropertiesDefaultWritten(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -2278,7 +2278,7 @@ func TestDesiredPropertiesRequestFromDeviceOnBoot(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_request_desired_props"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cfg",
@@ -2365,7 +2365,7 @@ func TestDesiredPropertiesRequestFromDeviceOnBoot(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)

--- a/internal/servers/protocmd_srv/server_integration_test.go
+++ b/internal/servers/protocmd_srv/server_integration_test.go
@@ -73,7 +73,7 @@ func TestPublishCmdListRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_list_cmd"
 	s := swarm.NewSwarm(mSdk.Bus)
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -134,7 +134,7 @@ func TestPublishCmdListFiltersRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_list_cmd_filters"
 	s := swarm.NewSwarm(mSdk.Bus)
-	if _, err := s.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	if _, err := s.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -190,7 +190,7 @@ func TestPublishCmdRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -243,7 +243,7 @@ func TestPublishCmdRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -305,7 +305,7 @@ func TestPublishCmdJsonRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd_json"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -357,7 +357,7 @@ func TestPublishCmdJsonRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -429,7 +429,7 @@ func TestPublishCmdNoDeviceFound(t *testing.T) {
 func TestPublishCmdProtoNoValidationDryRun(t *testing.T) {
 	// Arrange
 	id := "proto_novalidation_dryrun"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -467,7 +467,7 @@ func TestPublishCmdProtoNoValidationDryRun(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -494,7 +494,7 @@ func TestPublishCmdProtoInvalidPayloadNoValidation(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd_no_validation"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -552,7 +552,7 @@ func TestPublishCmdProtoInvalidPayloadNoValidation(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -585,7 +585,7 @@ func TestPublishCmdRequestMultipleDevices(t *testing.T) {
 	cmdHandled := &protocmd_testv1.ChangePower{}
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
-	_, err := swarm.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	_, err := swarm.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "device_send_cmd_1",
 			Namespace: "testing_cmd",
@@ -599,7 +599,7 @@ func TestPublishCmdRequestMultipleDevices(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "device_send_cmd_1",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "device_send_cmd_2",
 			Namespace: "testing_cmd",
@@ -676,7 +676,7 @@ func TestPublishCmdRequestMultipleDevicesOneNoHandler(t *testing.T) {
 	cmdHandled := &protocmd_testv1.ChangePower{}
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
-	_, err := swarm.AddDevices(&mir_apiv1.CreateDeviceRequest_Device{
+	_, err := swarm.AddDevices(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "device_send_cmd_1_no_handler",
 			Namespace: "testing_cmd",
@@ -690,7 +690,7 @@ func TestPublishCmdRequestMultipleDevicesOneNoHandler(t *testing.T) {
 		Spec: &mir_apiv1.DeviceSpec{
 			DeviceId: "device_send_cmd_1_no_handler",
 		},
-	}, &mir_apiv1.CreateDeviceRequest_Device{
+	}, &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "device_send_cmd_2_no_handler",
 			Namespace: "testing_cmd",
@@ -714,7 +714,7 @@ func TestPublishCmdRequestMultipleDevicesOneNoHandler(t *testing.T) {
 				return &protocmd_testv1.ChangePowerResp{Success: true}, nil
 			},
 		).Incubate()
-	swarm.AddDevice(&mir_apiv1.CreateDeviceRequest_Device{
+	swarm.AddDevice(&mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      "device_send_cmd_3_no_handler",
 			Namespace: "testing_cmd",
@@ -786,7 +786,7 @@ func TestPublishCmdRequestMultipleDevicesOneTimeout(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd_multi_timeout"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -810,7 +810,7 @@ func TestPublishCmdRequestMultipleDevicesOneTimeout(t *testing.T) {
 	}
 
 	id2 := "device_send_cmd_multi_timeout_2"
-	reqCreate2 := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate2 := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id2,
 			Namespace: "testing_cmd",
@@ -856,14 +856,14 @@ func TestPublishCmdRequestMultipleDevicesOneTimeout(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
 	}
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate2},
+			Device: reqCreate2,
 		})
 	if err != nil {
 		t.Error(err)
@@ -913,7 +913,7 @@ func TestPublishCmdRequestMultipleDevicesJson(t *testing.T) {
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
 	_, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -923,7 +923,7 @@ func TestPublishCmdRequestMultipleDevicesJson(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_send_cmd_multi_json_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -997,7 +997,7 @@ func TestPublishCmdRequestMultipleDevicesDescriptorNotFound(t *testing.T) {
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
 	_, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1007,7 +1007,7 @@ func TestPublishCmdRequestMultipleDevicesDescriptorNotFound(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_send_notfound_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1072,7 +1072,7 @@ func TestPublishCmdRequestMultipleDevicesSingleDescriptorNotFoundForcePush(t *te
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	handlerCount := 0
 	_, err := swarm.AddDevice(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1093,7 +1093,7 @@ func TestPublishCmdRequestMultipleDevicesSingleDescriptorNotFoundForcePush(t *te
 			},
 		).Incubate()
 	_, err = swarm.AddDevice(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1166,7 +1166,7 @@ func TestPublishCmdRequestMultipleDevicesJsonTemplate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	swarm := swarm.NewSwarm(mSdk.Bus)
 	_, err := swarm.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1179,7 +1179,7 @@ func TestPublishCmdRequestMultipleDevicesJsonTemplate(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: "device_send_cmd_multi_json_tlm_1",
 			},
-		}, &mir_apiv1.CreateDeviceRequest_Device{
+		}, &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Namespace: "testing_cmd",
 				Labels: map[string]string{
@@ -1234,7 +1234,7 @@ func TestPublishCmdRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd_multi_timeout_json_template_1"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -1258,7 +1258,7 @@ func TestPublishCmdRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	}
 
 	id2 := "device_send_cmd_multi_timeout_json_template_2"
-	reqCreate2 := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate2 := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id2,
 			Namespace: "testing_cmd",
@@ -1287,14 +1287,14 @@ func TestPublishCmdRequestMultipleDevicesOneTimeoutJsonTemplate(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
 	}
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate2},
+			Device: reqCreate2,
 		})
 	if err != nil {
 		t.Error(err)
@@ -1332,7 +1332,7 @@ func TestPublishCmdJsonNameWithCurlyRequest(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_send_cmd_json_curly"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_cmd",
@@ -1384,7 +1384,7 @@ func TestPublishCmdJsonNameWithCurlyRequest(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)

--- a/internal/servers/prototlm_srv/server_integration_test.go
+++ b/internal/servers/prototlm_srv/server_integration_test.go
@@ -79,7 +79,7 @@ func TestPublishDevicePushTelemetry(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_push_tlm"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -102,7 +102,7 @@ func TestPublishDevicePushTelemetry(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -198,7 +198,7 @@ func TestPublishDeviceSchemaAlreadyPresent(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_schema_present"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -242,7 +242,7 @@ func TestPublishDeviceSchemaAlreadyPresent(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -336,7 +336,7 @@ func TestPublishDeviceSchemaInvalid(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_invalid_schema"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -384,7 +384,7 @@ func TestPublishDeviceSchemaInvalid(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -482,7 +482,7 @@ func TestPublishDevicePushTelemetryDeviceUpdate(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	id := "device_push_tlm_upd"
-	reqCreate := &mir_apiv1.CreateDeviceRequest_Device{
+	reqCreate := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:      id,
 			Namespace: "testing_core",
@@ -505,7 +505,7 @@ func TestPublishDevicePushTelemetryDeviceUpdate(t *testing.T) {
 	// Act
 	_, err = core_client.PublishDeviceCreateRequest(mSdk.Bus,
 		&mir_apiv1.CreateDeviceRequest{
-			Devices: []*mir_apiv1.CreateDeviceRequest_Device{reqCreate},
+			Device: reqCreate,
 		})
 	if err != nil {
 		t.Error(err)
@@ -592,7 +592,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
 	_, err := s.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_1",
 				Namespace: "testing_core",
@@ -604,7 +604,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 				DeviceId: "dev_tlm_list_1",
 			},
 		},
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_2",
 				Namespace: "testing_core",
@@ -619,7 +619,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 		prototlm_testv1.File_prototlm_test_v1_telemetry_proto,
 	).Incubate()
 	_, err = s.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_3",
 				Namespace: "testing_core",
@@ -631,7 +631,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 				DeviceId: "dev_tlm_list_3",
 			},
 		},
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_4",
 				Namespace: "testing_core",
@@ -646,7 +646,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 		prototlm_testv1.File_prototlm_test_v1_telemetry2_proto,
 	).Incubate()
 	_, err = s.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_5",
 				Namespace: "testing_core",
@@ -658,7 +658,7 @@ func TestPublishTelemetryListPairs(t *testing.T) {
 				DeviceId: "dev_tlm_list_5",
 			},
 		},
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_6",
 				Namespace: "testing_core",
@@ -723,7 +723,7 @@ func TestPublishTelemetryList(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := swarm.NewSwarm(mSdk.Bus)
 	_, err := s.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_listing_!",
 				Namespace: "testing_core",
@@ -797,7 +797,7 @@ func TestPublishTelemetryListError(t *testing.T) {
 	// Arrange
 	s := swarm.NewSwarm(mSdk.Bus)
 	_, err := s.AddDevices(
-		&mir_apiv1.CreateDeviceRequest_Device{
+		&mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      "dev_tlm_list_offline",
 				Namespace: "testing_core",

--- a/internal/services/schema_cache/proto_cache_integration_test.go
+++ b/internal/services/schema_cache/proto_cache_integration_test.go
@@ -81,7 +81,7 @@ func TestPublishDeviceUpdateCache(t *testing.T) {
 	})
 
 	reqCreate := &mir_apiv1.CreateDeviceRequest{
-		Devices: []*mir_apiv1.CreateDeviceRequest_Device{{
+		Device: &mir_apiv1.NewDevice{
 			Meta: &mir_apiv1.Meta{
 				Name:      id,
 				Namespace: "testing_cmd",
@@ -92,7 +92,7 @@ func TestPublishDeviceUpdateCache(t *testing.T) {
 			Spec: &mir_apiv1.DeviceSpec{
 				DeviceId: id,
 			},
-		}},
+		},
 	}
 
 	dev, err := mirDevice.Builder().ExcludeSchemaOnLaunch().DeviceId(id).Store(mirDevice.StoreOptions{InMemory: true}).Target(busUrl).Schema(

--- a/internal/services/swarm_srvc/swarm.go
+++ b/internal/services/swarm_srvc/swarm.go
@@ -124,9 +124,9 @@ func (s *SwarmService) Deploy(ctx context.Context) ([]*sync.WaitGroup, error) {
 func createSwarmForDeviceGroup(swarmCfg mir_v1.Swarm, bus *nats.Conn, mirCtx ui.Context, protoFiles map[string][]*descriptorpb.FileDescriptorProto) (swarm.Swarm, error) {
 	s := swarm.NewSwarm(bus)
 	for _, devGroup := range swarmCfg.Spec.Devices {
-		createReqs := make([]*mir_apiv1.CreateDeviceRequest_Device, devGroup.Count)
+		createReqs := make([]*mir_apiv1.NewDevice, devGroup.Count)
 		if devGroup.Count == 1 {
-			createReqs[0] = &mir_apiv1.CreateDeviceRequest_Device{
+			createReqs[0] = &mir_apiv1.NewDevice{
 				Meta: &mir_apiv1.Meta{
 					Name:        devGroup.Meta.Name,
 					Namespace:   devGroup.Meta.Namespace,
@@ -139,7 +139,7 @@ func createSwarmForDeviceGroup(swarmCfg mir_v1.Swarm, bus *nats.Conn, mirCtx ui.
 			}
 		} else {
 			for i := range devGroup.Count {
-				createReqs[i] = &mir_apiv1.CreateDeviceRequest_Device{
+				createReqs[i] = &mir_apiv1.NewDevice{
 					Meta: &mir_apiv1.Meta{
 						Name:        devGroup.Meta.Name + "__" + strconv.Itoa(i),
 						Namespace:   devGroup.Meta.Namespace,

--- a/internal/ui/cli/device_cmd.go
+++ b/internal/ui/cli/device_cmd.go
@@ -209,25 +209,32 @@ func (d *DeviceCreateCmd) Run(log zerolog.Logger, m *mir.Mir) error {
 		devs = append(devs, &dev)
 	}
 
-	list := []mir_v1.Device{}
-	var errs error
-	for _, d := range devs {
-		respD, err := m.Client().CreateDevice().Request(*d)
+	devsNew := []mir_v1.Device{}
+	if len(devs) == 1 {
+		respD, err := m.Client().CreateDevice().Request(*devs[0])
 		if err != nil {
-			errs = errors.Join(errs, err)
-		} else {
-			list = append(list, respD)
+			return err
+		}
+		devsNew = append(devsNew, respD)
+	} else {
+		list := []mir_v1.Device{}
+		for _, d := range devs {
+			list = append(list, *d)
+		}
+		devsNew, err = m.Client().CreateDevices().Request(list)
+		if err != nil {
+			return err
 		}
 	}
 
-	if len(list) > 0 {
-		if str, err := stringifyDevices(d.Output, list); err != nil {
+	if len(devsNew) > 0 {
+		if str, err := stringifyDevices(d.Output, devsNew); err != nil {
 			return fmt.Errorf("error marshalling response: %w", err)
 		} else {
 			fmt.Println(str)
 		}
 	}
-	return errs
+	return nil
 }
 
 func (d *DeviceUpdateCmd) Validate() error {

--- a/justfile
+++ b/justfile
@@ -74,6 +74,10 @@ tx-serve:
 tx-full:
 	tmuxifier s ./.tmux/mir-full.session.sh
 
+# Start tmux layouts with local test setup
+tx-test:
+	tmuxifier s ./.tmux/mir-test.session.sh
+
 # Run supporting infra with docker
 infra:
 	docker compose -f infra/compose/local_support/compose.yaml up --force-recreate

--- a/pkgs/api/gen/proto/mir_api/v1/core.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/core.pb.go
@@ -24,8 +24,8 @@ const (
 
 // Send a request to create a new device in the system
 type CreateDeviceRequest struct {
-	state         protoimpl.MessageState        `protogen:"open.v1"`
-	Devices       []*CreateDeviceRequest_Device `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"` // Represent the specifications that can be updated
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Device        *NewDevice             `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"` // Represent the specifications that can be updated
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -60,9 +60,9 @@ func (*CreateDeviceRequest) Descriptor() ([]byte, []int) {
 	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *CreateDeviceRequest) GetDevices() []*CreateDeviceRequest_Device {
+func (x *CreateDeviceRequest) GetDevice() *NewDevice {
 	if x != nil {
-		return x.Devices
+		return x.Device
 	}
 	return nil
 }
@@ -70,9 +70,12 @@ func (x *CreateDeviceRequest) GetDevices() []*CreateDeviceRequest_Device {
 // Response to multiple create device request
 // Only the error or the response data will be set
 type CreateDeviceResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ok            *DeviceList            `protobuf:"bytes,1,opt,name=ok,proto3" json:"ok,omitempty"`       // devices that were created
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"` // Error message if troubleshooting is needed
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Response:
+	//
+	//	*CreateDeviceResponse_Ok
+	//	*CreateDeviceResponse_Error
+	Response      isCreateDeviceResponse_Response `protobuf_oneof:"response"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -107,19 +110,175 @@ func (*CreateDeviceResponse) Descriptor() ([]byte, []int) {
 	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *CreateDeviceResponse) GetOk() *DeviceList {
+func (x *CreateDeviceResponse) GetResponse() isCreateDeviceResponse_Response {
 	if x != nil {
-		return x.Ok
+		return x.Response
+	}
+	return nil
+}
+
+func (x *CreateDeviceResponse) GetOk() *Device {
+	if x != nil {
+		if x, ok := x.Response.(*CreateDeviceResponse_Ok); ok {
+			return x.Ok
+		}
 	}
 	return nil
 }
 
 func (x *CreateDeviceResponse) GetError() string {
 	if x != nil {
-		return x.Error
+		if x, ok := x.Response.(*CreateDeviceResponse_Error); ok {
+			return x.Error
+		}
 	}
 	return ""
 }
+
+type isCreateDeviceResponse_Response interface {
+	isCreateDeviceResponse_Response()
+}
+
+type CreateDeviceResponse_Ok struct {
+	Ok *Device `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // device that were created
+}
+
+type CreateDeviceResponse_Error struct {
+	Error string `protobuf:"bytes,2,opt,name=error,proto3,oneof"` // Error message if troubleshooting is needed
+}
+
+func (*CreateDeviceResponse_Ok) isCreateDeviceResponse_Response() {}
+
+func (*CreateDeviceResponse_Error) isCreateDeviceResponse_Response() {}
+
+// Send a request to create a new device in the system
+type CreateDevicesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Devices       []*NewDevice           `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"` // Represent the specifications that can be updated
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDevicesRequest) Reset() {
+	*x = CreateDevicesRequest{}
+	mi := &file_mir_api_v1_core_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDevicesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDevicesRequest) ProtoMessage() {}
+
+func (x *CreateDevicesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_mir_api_v1_core_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDevicesRequest.ProtoReflect.Descriptor instead.
+func (*CreateDevicesRequest) Descriptor() ([]byte, []int) {
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CreateDevicesRequest) GetDevices() []*NewDevice {
+	if x != nil {
+		return x.Devices
+	}
+	return nil
+}
+
+// Response to multiple create device request
+// Only the error or the response data will be set
+type CreateDevicesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Response:
+	//
+	//	*CreateDevicesResponse_Ok
+	//	*CreateDevicesResponse_Error
+	Response      isCreateDevicesResponse_Response `protobuf_oneof:"response"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDevicesResponse) Reset() {
+	*x = CreateDevicesResponse{}
+	mi := &file_mir_api_v1_core_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDevicesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDevicesResponse) ProtoMessage() {}
+
+func (x *CreateDevicesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mir_api_v1_core_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDevicesResponse.ProtoReflect.Descriptor instead.
+func (*CreateDevicesResponse) Descriptor() ([]byte, []int) {
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *CreateDevicesResponse) GetResponse() isCreateDevicesResponse_Response {
+	if x != nil {
+		return x.Response
+	}
+	return nil
+}
+
+func (x *CreateDevicesResponse) GetOk() *DeviceList {
+	if x != nil {
+		if x, ok := x.Response.(*CreateDevicesResponse_Ok); ok {
+			return x.Ok
+		}
+	}
+	return nil
+}
+
+func (x *CreateDevicesResponse) GetError() string {
+	if x != nil {
+		if x, ok := x.Response.(*CreateDevicesResponse_Error); ok {
+			return x.Error
+		}
+	}
+	return ""
+}
+
+type isCreateDevicesResponse_Response interface {
+	isCreateDevicesResponse_Response()
+}
+
+type CreateDevicesResponse_Ok struct {
+	Ok *DeviceList `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // devices that were created
+}
+
+type CreateDevicesResponse_Error struct {
+	Error string `protobuf:"bytes,2,opt,name=error,proto3,oneof"` // Error message if troubleshooting is needed
+}
+
+func (*CreateDevicesResponse_Ok) isCreateDevicesResponse_Response() {}
+
+func (*CreateDevicesResponse_Error) isCreateDevicesResponse_Response() {}
 
 // Send a request to update a device in the system
 // - Optional field, means can be nil
@@ -138,7 +297,7 @@ type UpdateDeviceRequest struct {
 
 func (x *UpdateDeviceRequest) Reset() {
 	*x = UpdateDeviceRequest{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[2]
+	mi := &file_mir_api_v1_core_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -150,7 +309,7 @@ func (x *UpdateDeviceRequest) String() string {
 func (*UpdateDeviceRequest) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[2]
+	mi := &file_mir_api_v1_core_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -163,7 +322,7 @@ func (x *UpdateDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *UpdateDeviceRequest) GetTargets() *DeviceTarget {
@@ -216,7 +375,7 @@ type UpdateDeviceResponse struct {
 
 func (x *UpdateDeviceResponse) Reset() {
 	*x = UpdateDeviceResponse{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[3]
+	mi := &file_mir_api_v1_core_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -228,7 +387,7 @@ func (x *UpdateDeviceResponse) String() string {
 func (*UpdateDeviceResponse) ProtoMessage() {}
 
 func (x *UpdateDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[3]
+	mi := &file_mir_api_v1_core_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -241,7 +400,7 @@ func (x *UpdateDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{3}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *UpdateDeviceResponse) GetResponse() isUpdateDeviceResponse_Response {
@@ -295,7 +454,7 @@ type MergeDeviceRequest struct {
 
 func (x *MergeDeviceRequest) Reset() {
 	*x = MergeDeviceRequest{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[4]
+	mi := &file_mir_api_v1_core_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -307,7 +466,7 @@ func (x *MergeDeviceRequest) String() string {
 func (*MergeDeviceRequest) ProtoMessage() {}
 
 func (x *MergeDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[4]
+	mi := &file_mir_api_v1_core_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -320,7 +479,7 @@ func (x *MergeDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MergeDeviceRequest.ProtoReflect.Descriptor instead.
 func (*MergeDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *MergeDeviceRequest) GetTargets() *DeviceTarget {
@@ -350,7 +509,7 @@ type MergeDeviceResponse struct {
 
 func (x *MergeDeviceResponse) Reset() {
 	*x = MergeDeviceResponse{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[5]
+	mi := &file_mir_api_v1_core_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -362,7 +521,7 @@ func (x *MergeDeviceResponse) String() string {
 func (*MergeDeviceResponse) ProtoMessage() {}
 
 func (x *MergeDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[5]
+	mi := &file_mir_api_v1_core_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -375,7 +534,7 @@ func (x *MergeDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MergeDeviceResponse.ProtoReflect.Descriptor instead.
 func (*MergeDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{5}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *MergeDeviceResponse) GetResponse() isMergeDeviceResponse_Response {
@@ -429,7 +588,7 @@ type DeleteDeviceRequest struct {
 
 func (x *DeleteDeviceRequest) Reset() {
 	*x = DeleteDeviceRequest{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[6]
+	mi := &file_mir_api_v1_core_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +600,7 @@ func (x *DeleteDeviceRequest) String() string {
 func (*DeleteDeviceRequest) ProtoMessage() {}
 
 func (x *DeleteDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[6]
+	mi := &file_mir_api_v1_core_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +613,7 @@ func (x *DeleteDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDeviceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{6}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DeleteDeviceRequest) GetTargets() *DeviceTarget {
@@ -479,7 +638,7 @@ type DeleteDeviceResponse struct {
 
 func (x *DeleteDeviceResponse) Reset() {
 	*x = DeleteDeviceResponse{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[7]
+	mi := &file_mir_api_v1_core_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -491,7 +650,7 @@ func (x *DeleteDeviceResponse) String() string {
 func (*DeleteDeviceResponse) ProtoMessage() {}
 
 func (x *DeleteDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[7]
+	mi := &file_mir_api_v1_core_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -504,7 +663,7 @@ func (x *DeleteDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDeviceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{7}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DeleteDeviceResponse) GetResponse() isDeleteDeviceResponse_Response {
@@ -559,7 +718,7 @@ type ListDeviceRequest struct {
 
 func (x *ListDeviceRequest) Reset() {
 	*x = ListDeviceRequest{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[8]
+	mi := &file_mir_api_v1_core_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -571,7 +730,7 @@ func (x *ListDeviceRequest) String() string {
 func (*ListDeviceRequest) ProtoMessage() {}
 
 func (x *ListDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[8]
+	mi := &file_mir_api_v1_core_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -584,7 +743,7 @@ func (x *ListDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeviceRequest.ProtoReflect.Descriptor instead.
 func (*ListDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{8}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListDeviceRequest) GetTargets() *DeviceTarget {
@@ -616,7 +775,7 @@ type ListDeviceResponse struct {
 
 func (x *ListDeviceResponse) Reset() {
 	*x = ListDeviceResponse{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[9]
+	mi := &file_mir_api_v1_core_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -628,7 +787,7 @@ func (x *ListDeviceResponse) String() string {
 func (*ListDeviceResponse) ProtoMessage() {}
 
 func (x *ListDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[9]
+	mi := &file_mir_api_v1_core_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -641,7 +800,7 @@ func (x *ListDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeviceResponse.ProtoReflect.Descriptor instead.
 func (*ListDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{9}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListDeviceResponse) GetResponse() isListDeviceResponse_Response {
@@ -699,7 +858,7 @@ type DeviceTarget struct {
 
 func (x *DeviceTarget) Reset() {
 	*x = DeviceTarget{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[10]
+	mi := &file_mir_api_v1_core_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -711,7 +870,7 @@ func (x *DeviceTarget) String() string {
 func (*DeviceTarget) ProtoMessage() {}
 
 func (x *DeviceTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[10]
+	mi := &file_mir_api_v1_core_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -724,7 +883,7 @@ func (x *DeviceTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceTarget.ProtoReflect.Descriptor instead.
 func (*DeviceTarget) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{10}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeviceTarget) GetNames() []string {
@@ -765,7 +924,7 @@ type DeviceList struct {
 
 func (x *DeviceList) Reset() {
 	*x = DeviceList{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[11]
+	mi := &file_mir_api_v1_core_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -777,7 +936,7 @@ func (x *DeviceList) String() string {
 func (*DeviceList) ProtoMessage() {}
 
 func (x *DeviceList) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[11]
+	mi := &file_mir_api_v1_core_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -790,7 +949,7 @@ func (x *DeviceList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceList.ProtoReflect.Descriptor instead.
 func (*DeviceList) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{11}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeviceList) GetDevices() []*Device {
@@ -810,7 +969,7 @@ type DeviceIdList struct {
 
 func (x *DeviceIdList) Reset() {
 	*x = DeviceIdList{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[12]
+	mi := &file_mir_api_v1_core_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +981,7 @@ func (x *DeviceIdList) String() string {
 func (*DeviceIdList) ProtoMessage() {}
 
 func (x *DeviceIdList) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[12]
+	mi := &file_mir_api_v1_core_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +994,7 @@ func (x *DeviceIdList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceIdList.ProtoReflect.Descriptor instead.
 func (*DeviceIdList) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{12}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeviceIdList) GetDeviceIds() []string {
@@ -860,7 +1019,7 @@ type Device struct {
 
 func (x *Device) Reset() {
 	*x = Device{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[13]
+	mi := &file_mir_api_v1_core_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -872,7 +1031,7 @@ func (x *Device) String() string {
 func (*Device) ProtoMessage() {}
 
 func (x *Device) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[13]
+	mi := &file_mir_api_v1_core_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -885,7 +1044,7 @@ func (x *Device) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Device.ProtoReflect.Descriptor instead.
 func (*Device) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{13}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Device) GetApiVersion() string {
@@ -930,6 +1089,58 @@ func (x *Device) GetStatus() *DeviceStatus {
 	return nil
 }
 
+type NewDevice struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Meta          *Meta                  `protobuf:"bytes,1,opt,name=meta,proto3" json:"meta,omitempty"` // Represent the specifications that can be updated
+	Spec          *DeviceSpec            `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"` // Represent device twin specific config from Mir
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NewDevice) Reset() {
+	*x = NewDevice{}
+	mi := &file_mir_api_v1_core_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NewDevice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NewDevice) ProtoMessage() {}
+
+func (x *NewDevice) ProtoReflect() protoreflect.Message {
+	mi := &file_mir_api_v1_core_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NewDevice.ProtoReflect.Descriptor instead.
+func (*NewDevice) Descriptor() ([]byte, []int) {
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *NewDevice) GetMeta() *Meta {
+	if x != nil {
+		return x.Meta
+	}
+	return nil
+}
+
+func (x *NewDevice) GetSpec() *DeviceSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
 // Represent configuration from Mir itself for the twin specifically
 type DeviceSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -941,7 +1152,7 @@ type DeviceSpec struct {
 
 func (x *DeviceSpec) Reset() {
 	*x = DeviceSpec{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[14]
+	mi := &file_mir_api_v1_core_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -953,7 +1164,7 @@ func (x *DeviceSpec) String() string {
 func (*DeviceSpec) ProtoMessage() {}
 
 func (x *DeviceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[14]
+	mi := &file_mir_api_v1_core_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -966,7 +1177,7 @@ func (x *DeviceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceSpec.ProtoReflect.Descriptor instead.
 func (*DeviceSpec) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{14}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *DeviceSpec) GetDeviceId() string {
@@ -995,7 +1206,7 @@ type DeviceProperties struct {
 
 func (x *DeviceProperties) Reset() {
 	*x = DeviceProperties{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[15]
+	mi := &file_mir_api_v1_core_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1007,7 +1218,7 @@ func (x *DeviceProperties) String() string {
 func (*DeviceProperties) ProtoMessage() {}
 
 func (x *DeviceProperties) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[15]
+	mi := &file_mir_api_v1_core_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1020,7 +1231,7 @@ func (x *DeviceProperties) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceProperties.ProtoReflect.Descriptor instead.
 func (*DeviceProperties) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{15}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DeviceProperties) GetDesired() *structpb.Struct {
@@ -1051,7 +1262,7 @@ type DeviceStatus struct {
 
 func (x *DeviceStatus) Reset() {
 	*x = DeviceStatus{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[16]
+	mi := &file_mir_api_v1_core_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1063,7 +1274,7 @@ func (x *DeviceStatus) String() string {
 func (*DeviceStatus) ProtoMessage() {}
 
 func (x *DeviceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[16]
+	mi := &file_mir_api_v1_core_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1076,7 +1287,7 @@ func (x *DeviceStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceStatus.ProtoReflect.Descriptor instead.
 func (*DeviceStatus) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{16}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeviceStatus) GetLastHearthbeat() *Timestamp {
@@ -1126,7 +1337,7 @@ type DeviceStatusEvent struct {
 
 func (x *DeviceStatusEvent) Reset() {
 	*x = DeviceStatusEvent{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[17]
+	mi := &file_mir_api_v1_core_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1138,7 +1349,7 @@ func (x *DeviceStatusEvent) String() string {
 func (*DeviceStatusEvent) ProtoMessage() {}
 
 func (x *DeviceStatusEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[17]
+	mi := &file_mir_api_v1_core_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1151,7 +1362,7 @@ func (x *DeviceStatusEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceStatusEvent.ProtoReflect.Descriptor instead.
 func (*DeviceStatusEvent) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{17}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DeviceStatusEvent) GetType() string {
@@ -1193,7 +1404,7 @@ type PropertiesTime struct {
 
 func (x *PropertiesTime) Reset() {
 	*x = PropertiesTime{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[18]
+	mi := &file_mir_api_v1_core_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1205,7 +1416,7 @@ func (x *PropertiesTime) String() string {
 func (*PropertiesTime) ProtoMessage() {}
 
 func (x *PropertiesTime) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[18]
+	mi := &file_mir_api_v1_core_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1218,7 +1429,7 @@ func (x *PropertiesTime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PropertiesTime.ProtoReflect.Descriptor instead.
 func (*PropertiesTime) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{18}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PropertiesTime) GetDesired() map[string]*Timestamp {
@@ -1246,7 +1457,7 @@ type Schema struct {
 
 func (x *Schema) Reset() {
 	*x = Schema{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[19]
+	mi := &file_mir_api_v1_core_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1258,7 +1469,7 @@ func (x *Schema) String() string {
 func (*Schema) ProtoMessage() {}
 
 func (x *Schema) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[19]
+	mi := &file_mir_api_v1_core_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1271,7 +1482,7 @@ func (x *Schema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Schema.ProtoReflect.Descriptor instead.
 func (*Schema) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{19}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Schema) GetCompressedSchema() []byte {
@@ -1295,58 +1506,6 @@ func (x *Schema) GetLastSchemaFetch() *Timestamp {
 	return nil
 }
 
-type CreateDeviceRequest_Device struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          *Meta                  `protobuf:"bytes,1,opt,name=meta,proto3" json:"meta,omitempty"` // Represent the specifications that can be updated
-	Spec          *DeviceSpec            `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"` // Represent device twin specific config from Mir
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CreateDeviceRequest_Device) Reset() {
-	*x = CreateDeviceRequest_Device{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[20]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CreateDeviceRequest_Device) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CreateDeviceRequest_Device) ProtoMessage() {}
-
-func (x *CreateDeviceRequest_Device) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[20]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CreateDeviceRequest_Device.ProtoReflect.Descriptor instead.
-func (*CreateDeviceRequest_Device) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{0, 0}
-}
-
-func (x *CreateDeviceRequest_Device) GetMeta() *Meta {
-	if x != nil {
-		return x.Meta
-	}
-	return nil
-}
-
-func (x *CreateDeviceRequest_Device) GetSpec() *DeviceSpec {
-	if x != nil {
-		return x.Spec
-	}
-	return nil
-}
-
 type UpdateDeviceRequest_Meta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          *string                `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`                                                                                   // Name of the device
@@ -1359,7 +1518,7 @@ type UpdateDeviceRequest_Meta struct {
 
 func (x *UpdateDeviceRequest_Meta) Reset() {
 	*x = UpdateDeviceRequest_Meta{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[21]
+	mi := &file_mir_api_v1_core_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1371,7 +1530,7 @@ func (x *UpdateDeviceRequest_Meta) String() string {
 func (*UpdateDeviceRequest_Meta) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_Meta) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[21]
+	mi := &file_mir_api_v1_core_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1384,7 +1543,7 @@ func (x *UpdateDeviceRequest_Meta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest_Meta.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_Meta) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 0}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 0}
 }
 
 func (x *UpdateDeviceRequest_Meta) GetName() string {
@@ -1425,7 +1584,7 @@ type UpdateDeviceRequest_Spec struct {
 
 func (x *UpdateDeviceRequest_Spec) Reset() {
 	*x = UpdateDeviceRequest_Spec{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[22]
+	mi := &file_mir_api_v1_core_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1437,7 +1596,7 @@ func (x *UpdateDeviceRequest_Spec) String() string {
 func (*UpdateDeviceRequest_Spec) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_Spec) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[22]
+	mi := &file_mir_api_v1_core_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1450,7 +1609,7 @@ func (x *UpdateDeviceRequest_Spec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest_Spec.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_Spec) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 1}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 1}
 }
 
 func (x *UpdateDeviceRequest_Spec) GetDeviceId() string {
@@ -1476,7 +1635,7 @@ type UpdateDeviceRequest_Properties struct {
 
 func (x *UpdateDeviceRequest_Properties) Reset() {
 	*x = UpdateDeviceRequest_Properties{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[23]
+	mi := &file_mir_api_v1_core_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1488,7 +1647,7 @@ func (x *UpdateDeviceRequest_Properties) String() string {
 func (*UpdateDeviceRequest_Properties) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_Properties) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[23]
+	mi := &file_mir_api_v1_core_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1501,7 +1660,7 @@ func (x *UpdateDeviceRequest_Properties) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest_Properties.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_Properties) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 2}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 2}
 }
 
 func (x *UpdateDeviceRequest_Properties) GetDesired() *structpb.Struct {
@@ -1523,7 +1682,7 @@ type UpdateDeviceRequest_Status struct {
 
 func (x *UpdateDeviceRequest_Status) Reset() {
 	*x = UpdateDeviceRequest_Status{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[24]
+	mi := &file_mir_api_v1_core_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1535,7 +1694,7 @@ func (x *UpdateDeviceRequest_Status) String() string {
 func (*UpdateDeviceRequest_Status) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_Status) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[24]
+	mi := &file_mir_api_v1_core_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1548,7 +1707,7 @@ func (x *UpdateDeviceRequest_Status) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest_Status.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_Status) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 3}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 3}
 }
 
 func (x *UpdateDeviceRequest_Status) GetOnline() bool {
@@ -1590,7 +1749,7 @@ type UpdateDeviceRequest_Schema struct {
 
 func (x *UpdateDeviceRequest_Schema) Reset() {
 	*x = UpdateDeviceRequest_Schema{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[25]
+	mi := &file_mir_api_v1_core_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1602,7 +1761,7 @@ func (x *UpdateDeviceRequest_Schema) String() string {
 func (*UpdateDeviceRequest_Schema) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_Schema) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[25]
+	mi := &file_mir_api_v1_core_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1615,7 +1774,7 @@ func (x *UpdateDeviceRequest_Schema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDeviceRequest_Schema.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_Schema) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 4}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 4}
 }
 
 func (x *UpdateDeviceRequest_Schema) GetCompressedSchema() []byte {
@@ -1649,7 +1808,7 @@ type UpdateDeviceRequest_PropertiesTime struct {
 
 func (x *UpdateDeviceRequest_PropertiesTime) Reset() {
 	*x = UpdateDeviceRequest_PropertiesTime{}
-	mi := &file_mir_api_v1_core_proto_msgTypes[26]
+	mi := &file_mir_api_v1_core_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1661,7 +1820,7 @@ func (x *UpdateDeviceRequest_PropertiesTime) String() string {
 func (*UpdateDeviceRequest_PropertiesTime) ProtoMessage() {}
 
 func (x *UpdateDeviceRequest_PropertiesTime) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_core_proto_msgTypes[26]
+	mi := &file_mir_api_v1_core_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1674,7 +1833,7 @@ func (x *UpdateDeviceRequest_PropertiesTime) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use UpdateDeviceRequest_PropertiesTime.ProtoReflect.Descriptor instead.
 func (*UpdateDeviceRequest_PropertiesTime) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{2, 5}
+	return file_mir_api_v1_core_proto_rawDescGZIP(), []int{4, 5}
 }
 
 func (x *UpdateDeviceRequest_PropertiesTime) GetDesired() map[string]*Timestamp {
@@ -1696,15 +1855,21 @@ var File_mir_api_v1_core_proto protoreflect.FileDescriptor
 const file_mir_api_v1_core_proto_rawDesc = "" +
 	"\n" +
 	"\x15mir_api/v1/core.proto\x12\n" +
-	"mir_api.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17mir_api/v1/common.proto\"\xb3\x01\n" +
-	"\x13CreateDeviceRequest\x12@\n" +
-	"\adevices\x18\x01 \x03(\v2&.mir_api.v1.CreateDeviceRequest.DeviceR\adevices\x1aZ\n" +
-	"\x06Device\x12$\n" +
-	"\x04meta\x18\x01 \x01(\v2\x10.mir_api.v1.MetaR\x04meta\x12*\n" +
-	"\x04spec\x18\x02 \x01(\v2\x16.mir_api.v1.DeviceSpecR\x04spec\"T\n" +
-	"\x14CreateDeviceResponse\x12&\n" +
-	"\x02ok\x18\x01 \x01(\v2\x16.mir_api.v1.DeviceListR\x02ok\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\xeb\r\n" +
+	"mir_api.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17mir_api/v1/common.proto\"D\n" +
+	"\x13CreateDeviceRequest\x12-\n" +
+	"\x06device\x18\x01 \x01(\v2\x15.mir_api.v1.NewDeviceR\x06device\"`\n" +
+	"\x14CreateDeviceResponse\x12$\n" +
+	"\x02ok\x18\x01 \x01(\v2\x12.mir_api.v1.DeviceH\x00R\x02ok\x12\x16\n" +
+	"\x05error\x18\x02 \x01(\tH\x00R\x05errorB\n" +
+	"\n" +
+	"\bresponse\"G\n" +
+	"\x14CreateDevicesRequest\x12/\n" +
+	"\adevices\x18\x01 \x03(\v2\x15.mir_api.v1.NewDeviceR\adevices\"e\n" +
+	"\x15CreateDevicesResponse\x12(\n" +
+	"\x02ok\x18\x01 \x01(\v2\x16.mir_api.v1.DeviceListH\x00R\x02ok\x12\x16\n" +
+	"\x05error\x18\x02 \x01(\tH\x00R\x05errorB\n" +
+	"\n" +
+	"\bresponse\"\xeb\r\n" +
 	"\x13UpdateDeviceRequest\x122\n" +
 	"\atargets\x18\x01 \x01(\v2\x18.mir_api.v1.DeviceTargetR\atargets\x128\n" +
 	"\x04meta\x18\x02 \x01(\v2$.mir_api.v1.UpdateDeviceRequest.MetaR\x04meta\x128\n" +
@@ -1811,7 +1976,10 @@ const file_mir_api_v1_core_proto_rawDesc = "" +
 	"\n" +
 	"properties\x18\x05 \x01(\v2\x1c.mir_api.v1.DevicePropertiesR\n" +
 	"properties\x120\n" +
-	"\x06status\x18\x06 \x01(\v2\x18.mir_api.v1.DeviceStatusR\x06status\"E\n" +
+	"\x06status\x18\x06 \x01(\v2\x18.mir_api.v1.DeviceStatusR\x06status\"]\n" +
+	"\tNewDevice\x12$\n" +
+	"\x04meta\x18\x01 \x01(\v2\x10.mir_api.v1.MetaR\x04meta\x12*\n" +
+	"\x04spec\x18\x02 \x01(\v2\x16.mir_api.v1.DeviceSpecR\x04spec\"E\n" +
 	"\n" +
 	"DeviceSpec\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1a\n" +
@@ -1860,101 +2028,105 @@ func file_mir_api_v1_core_proto_rawDescGZIP() []byte {
 	return file_mir_api_v1_core_proto_rawDescData
 }
 
-var file_mir_api_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_mir_api_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_mir_api_v1_core_proto_goTypes = []any{
 	(*CreateDeviceRequest)(nil),                // 0: mir_api.v1.CreateDeviceRequest
 	(*CreateDeviceResponse)(nil),               // 1: mir_api.v1.CreateDeviceResponse
-	(*UpdateDeviceRequest)(nil),                // 2: mir_api.v1.UpdateDeviceRequest
-	(*UpdateDeviceResponse)(nil),               // 3: mir_api.v1.UpdateDeviceResponse
-	(*MergeDeviceRequest)(nil),                 // 4: mir_api.v1.MergeDeviceRequest
-	(*MergeDeviceResponse)(nil),                // 5: mir_api.v1.MergeDeviceResponse
-	(*DeleteDeviceRequest)(nil),                // 6: mir_api.v1.DeleteDeviceRequest
-	(*DeleteDeviceResponse)(nil),               // 7: mir_api.v1.DeleteDeviceResponse
-	(*ListDeviceRequest)(nil),                  // 8: mir_api.v1.ListDeviceRequest
-	(*ListDeviceResponse)(nil),                 // 9: mir_api.v1.ListDeviceResponse
-	(*DeviceTarget)(nil),                       // 10: mir_api.v1.DeviceTarget
-	(*DeviceList)(nil),                         // 11: mir_api.v1.DeviceList
-	(*DeviceIdList)(nil),                       // 12: mir_api.v1.DeviceIdList
-	(*Device)(nil),                             // 13: mir_api.v1.Device
-	(*DeviceSpec)(nil),                         // 14: mir_api.v1.DeviceSpec
-	(*DeviceProperties)(nil),                   // 15: mir_api.v1.DeviceProperties
-	(*DeviceStatus)(nil),                       // 16: mir_api.v1.DeviceStatus
-	(*DeviceStatusEvent)(nil),                  // 17: mir_api.v1.DeviceStatusEvent
-	(*PropertiesTime)(nil),                     // 18: mir_api.v1.PropertiesTime
-	(*Schema)(nil),                             // 19: mir_api.v1.Schema
-	(*CreateDeviceRequest_Device)(nil),         // 20: mir_api.v1.CreateDeviceRequest.Device
-	(*UpdateDeviceRequest_Meta)(nil),           // 21: mir_api.v1.UpdateDeviceRequest.Meta
-	(*UpdateDeviceRequest_Spec)(nil),           // 22: mir_api.v1.UpdateDeviceRequest.Spec
-	(*UpdateDeviceRequest_Properties)(nil),     // 23: mir_api.v1.UpdateDeviceRequest.Properties
-	(*UpdateDeviceRequest_Status)(nil),         // 24: mir_api.v1.UpdateDeviceRequest.Status
-	(*UpdateDeviceRequest_Schema)(nil),         // 25: mir_api.v1.UpdateDeviceRequest.Schema
-	(*UpdateDeviceRequest_PropertiesTime)(nil), // 26: mir_api.v1.UpdateDeviceRequest.PropertiesTime
-	nil,                     // 27: mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry
-	nil,                     // 28: mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry
-	nil,                     // 29: mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry
-	nil,                     // 30: mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry
-	nil,                     // 31: mir_api.v1.DeviceTarget.LabelsEntry
-	nil,                     // 32: mir_api.v1.PropertiesTime.DesiredEntry
-	nil,                     // 33: mir_api.v1.PropertiesTime.ReportedEntry
-	(*structpb.Struct)(nil), // 34: google.protobuf.Struct
-	(*Meta)(nil),            // 35: mir_api.v1.Meta
-	(*Timestamp)(nil),       // 36: mir_api.v1.Timestamp
-	(*OptString)(nil),       // 37: mir_api.v1.OptString
+	(*CreateDevicesRequest)(nil),               // 2: mir_api.v1.CreateDevicesRequest
+	(*CreateDevicesResponse)(nil),              // 3: mir_api.v1.CreateDevicesResponse
+	(*UpdateDeviceRequest)(nil),                // 4: mir_api.v1.UpdateDeviceRequest
+	(*UpdateDeviceResponse)(nil),               // 5: mir_api.v1.UpdateDeviceResponse
+	(*MergeDeviceRequest)(nil),                 // 6: mir_api.v1.MergeDeviceRequest
+	(*MergeDeviceResponse)(nil),                // 7: mir_api.v1.MergeDeviceResponse
+	(*DeleteDeviceRequest)(nil),                // 8: mir_api.v1.DeleteDeviceRequest
+	(*DeleteDeviceResponse)(nil),               // 9: mir_api.v1.DeleteDeviceResponse
+	(*ListDeviceRequest)(nil),                  // 10: mir_api.v1.ListDeviceRequest
+	(*ListDeviceResponse)(nil),                 // 11: mir_api.v1.ListDeviceResponse
+	(*DeviceTarget)(nil),                       // 12: mir_api.v1.DeviceTarget
+	(*DeviceList)(nil),                         // 13: mir_api.v1.DeviceList
+	(*DeviceIdList)(nil),                       // 14: mir_api.v1.DeviceIdList
+	(*Device)(nil),                             // 15: mir_api.v1.Device
+	(*NewDevice)(nil),                          // 16: mir_api.v1.NewDevice
+	(*DeviceSpec)(nil),                         // 17: mir_api.v1.DeviceSpec
+	(*DeviceProperties)(nil),                   // 18: mir_api.v1.DeviceProperties
+	(*DeviceStatus)(nil),                       // 19: mir_api.v1.DeviceStatus
+	(*DeviceStatusEvent)(nil),                  // 20: mir_api.v1.DeviceStatusEvent
+	(*PropertiesTime)(nil),                     // 21: mir_api.v1.PropertiesTime
+	(*Schema)(nil),                             // 22: mir_api.v1.Schema
+	(*UpdateDeviceRequest_Meta)(nil),           // 23: mir_api.v1.UpdateDeviceRequest.Meta
+	(*UpdateDeviceRequest_Spec)(nil),           // 24: mir_api.v1.UpdateDeviceRequest.Spec
+	(*UpdateDeviceRequest_Properties)(nil),     // 25: mir_api.v1.UpdateDeviceRequest.Properties
+	(*UpdateDeviceRequest_Status)(nil),         // 26: mir_api.v1.UpdateDeviceRequest.Status
+	(*UpdateDeviceRequest_Schema)(nil),         // 27: mir_api.v1.UpdateDeviceRequest.Schema
+	(*UpdateDeviceRequest_PropertiesTime)(nil), // 28: mir_api.v1.UpdateDeviceRequest.PropertiesTime
+	nil,                     // 29: mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry
+	nil,                     // 30: mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry
+	nil,                     // 31: mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry
+	nil,                     // 32: mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry
+	nil,                     // 33: mir_api.v1.DeviceTarget.LabelsEntry
+	nil,                     // 34: mir_api.v1.PropertiesTime.DesiredEntry
+	nil,                     // 35: mir_api.v1.PropertiesTime.ReportedEntry
+	(*structpb.Struct)(nil), // 36: google.protobuf.Struct
+	(*Meta)(nil),            // 37: mir_api.v1.Meta
+	(*Timestamp)(nil),       // 38: mir_api.v1.Timestamp
+	(*OptString)(nil),       // 39: mir_api.v1.OptString
 }
 var file_mir_api_v1_core_proto_depIdxs = []int32{
-	20, // 0: mir_api.v1.CreateDeviceRequest.devices:type_name -> mir_api.v1.CreateDeviceRequest.Device
-	11, // 1: mir_api.v1.CreateDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
-	10, // 2: mir_api.v1.UpdateDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	21, // 3: mir_api.v1.UpdateDeviceRequest.meta:type_name -> mir_api.v1.UpdateDeviceRequest.Meta
-	22, // 4: mir_api.v1.UpdateDeviceRequest.spec:type_name -> mir_api.v1.UpdateDeviceRequest.Spec
-	23, // 5: mir_api.v1.UpdateDeviceRequest.props:type_name -> mir_api.v1.UpdateDeviceRequest.Properties
-	24, // 6: mir_api.v1.UpdateDeviceRequest.status:type_name -> mir_api.v1.UpdateDeviceRequest.Status
-	11, // 7: mir_api.v1.UpdateDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
-	10, // 8: mir_api.v1.MergeDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	34, // 9: mir_api.v1.MergeDeviceRequest.device:type_name -> google.protobuf.Struct
-	11, // 10: mir_api.v1.MergeDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
-	10, // 11: mir_api.v1.DeleteDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	11, // 12: mir_api.v1.DeleteDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
-	10, // 13: mir_api.v1.ListDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	11, // 14: mir_api.v1.ListDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
-	31, // 15: mir_api.v1.DeviceTarget.labels:type_name -> mir_api.v1.DeviceTarget.LabelsEntry
-	13, // 16: mir_api.v1.DeviceList.devices:type_name -> mir_api.v1.Device
-	35, // 17: mir_api.v1.Device.meta:type_name -> mir_api.v1.Meta
-	14, // 18: mir_api.v1.Device.spec:type_name -> mir_api.v1.DeviceSpec
-	15, // 19: mir_api.v1.Device.properties:type_name -> mir_api.v1.DeviceProperties
-	16, // 20: mir_api.v1.Device.status:type_name -> mir_api.v1.DeviceStatus
-	34, // 21: mir_api.v1.DeviceProperties.desired:type_name -> google.protobuf.Struct
-	34, // 22: mir_api.v1.DeviceProperties.reported:type_name -> google.protobuf.Struct
-	36, // 23: mir_api.v1.DeviceStatus.last_hearthbeat:type_name -> mir_api.v1.Timestamp
-	19, // 24: mir_api.v1.DeviceStatus.schema:type_name -> mir_api.v1.Schema
-	18, // 25: mir_api.v1.DeviceStatus.properties:type_name -> mir_api.v1.PropertiesTime
-	17, // 26: mir_api.v1.DeviceStatus.events:type_name -> mir_api.v1.DeviceStatusEvent
-	36, // 27: mir_api.v1.DeviceStatusEvent.first_at:type_name -> mir_api.v1.Timestamp
-	32, // 28: mir_api.v1.PropertiesTime.desired:type_name -> mir_api.v1.PropertiesTime.DesiredEntry
-	33, // 29: mir_api.v1.PropertiesTime.reported:type_name -> mir_api.v1.PropertiesTime.ReportedEntry
-	36, // 30: mir_api.v1.Schema.last_schema_fetch:type_name -> mir_api.v1.Timestamp
-	35, // 31: mir_api.v1.CreateDeviceRequest.Device.meta:type_name -> mir_api.v1.Meta
-	14, // 32: mir_api.v1.CreateDeviceRequest.Device.spec:type_name -> mir_api.v1.DeviceSpec
-	27, // 33: mir_api.v1.UpdateDeviceRequest.Meta.labels:type_name -> mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry
-	28, // 34: mir_api.v1.UpdateDeviceRequest.Meta.annotations:type_name -> mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry
-	34, // 35: mir_api.v1.UpdateDeviceRequest.Properties.desired:type_name -> google.protobuf.Struct
-	36, // 36: mir_api.v1.UpdateDeviceRequest.Status.last_hearthbeat:type_name -> mir_api.v1.Timestamp
-	25, // 37: mir_api.v1.UpdateDeviceRequest.Status.schema:type_name -> mir_api.v1.UpdateDeviceRequest.Schema
-	26, // 38: mir_api.v1.UpdateDeviceRequest.Status.properties:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime
-	36, // 39: mir_api.v1.UpdateDeviceRequest.Schema.last_schema_fetch:type_name -> mir_api.v1.Timestamp
-	29, // 40: mir_api.v1.UpdateDeviceRequest.PropertiesTime.desired:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry
-	30, // 41: mir_api.v1.UpdateDeviceRequest.PropertiesTime.reported:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry
-	37, // 42: mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry.value:type_name -> mir_api.v1.OptString
-	37, // 43: mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry.value:type_name -> mir_api.v1.OptString
-	36, // 44: mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry.value:type_name -> mir_api.v1.Timestamp
-	36, // 45: mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry.value:type_name -> mir_api.v1.Timestamp
-	36, // 46: mir_api.v1.PropertiesTime.DesiredEntry.value:type_name -> mir_api.v1.Timestamp
-	36, // 47: mir_api.v1.PropertiesTime.ReportedEntry.value:type_name -> mir_api.v1.Timestamp
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	16, // 0: mir_api.v1.CreateDeviceRequest.device:type_name -> mir_api.v1.NewDevice
+	15, // 1: mir_api.v1.CreateDeviceResponse.ok:type_name -> mir_api.v1.Device
+	16, // 2: mir_api.v1.CreateDevicesRequest.devices:type_name -> mir_api.v1.NewDevice
+	13, // 3: mir_api.v1.CreateDevicesResponse.ok:type_name -> mir_api.v1.DeviceList
+	12, // 4: mir_api.v1.UpdateDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	23, // 5: mir_api.v1.UpdateDeviceRequest.meta:type_name -> mir_api.v1.UpdateDeviceRequest.Meta
+	24, // 6: mir_api.v1.UpdateDeviceRequest.spec:type_name -> mir_api.v1.UpdateDeviceRequest.Spec
+	25, // 7: mir_api.v1.UpdateDeviceRequest.props:type_name -> mir_api.v1.UpdateDeviceRequest.Properties
+	26, // 8: mir_api.v1.UpdateDeviceRequest.status:type_name -> mir_api.v1.UpdateDeviceRequest.Status
+	13, // 9: mir_api.v1.UpdateDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
+	12, // 10: mir_api.v1.MergeDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	36, // 11: mir_api.v1.MergeDeviceRequest.device:type_name -> google.protobuf.Struct
+	13, // 12: mir_api.v1.MergeDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
+	12, // 13: mir_api.v1.DeleteDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	13, // 14: mir_api.v1.DeleteDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
+	12, // 15: mir_api.v1.ListDeviceRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	13, // 16: mir_api.v1.ListDeviceResponse.ok:type_name -> mir_api.v1.DeviceList
+	33, // 17: mir_api.v1.DeviceTarget.labels:type_name -> mir_api.v1.DeviceTarget.LabelsEntry
+	15, // 18: mir_api.v1.DeviceList.devices:type_name -> mir_api.v1.Device
+	37, // 19: mir_api.v1.Device.meta:type_name -> mir_api.v1.Meta
+	17, // 20: mir_api.v1.Device.spec:type_name -> mir_api.v1.DeviceSpec
+	18, // 21: mir_api.v1.Device.properties:type_name -> mir_api.v1.DeviceProperties
+	19, // 22: mir_api.v1.Device.status:type_name -> mir_api.v1.DeviceStatus
+	37, // 23: mir_api.v1.NewDevice.meta:type_name -> mir_api.v1.Meta
+	17, // 24: mir_api.v1.NewDevice.spec:type_name -> mir_api.v1.DeviceSpec
+	36, // 25: mir_api.v1.DeviceProperties.desired:type_name -> google.protobuf.Struct
+	36, // 26: mir_api.v1.DeviceProperties.reported:type_name -> google.protobuf.Struct
+	38, // 27: mir_api.v1.DeviceStatus.last_hearthbeat:type_name -> mir_api.v1.Timestamp
+	22, // 28: mir_api.v1.DeviceStatus.schema:type_name -> mir_api.v1.Schema
+	21, // 29: mir_api.v1.DeviceStatus.properties:type_name -> mir_api.v1.PropertiesTime
+	20, // 30: mir_api.v1.DeviceStatus.events:type_name -> mir_api.v1.DeviceStatusEvent
+	38, // 31: mir_api.v1.DeviceStatusEvent.first_at:type_name -> mir_api.v1.Timestamp
+	34, // 32: mir_api.v1.PropertiesTime.desired:type_name -> mir_api.v1.PropertiesTime.DesiredEntry
+	35, // 33: mir_api.v1.PropertiesTime.reported:type_name -> mir_api.v1.PropertiesTime.ReportedEntry
+	38, // 34: mir_api.v1.Schema.last_schema_fetch:type_name -> mir_api.v1.Timestamp
+	29, // 35: mir_api.v1.UpdateDeviceRequest.Meta.labels:type_name -> mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry
+	30, // 36: mir_api.v1.UpdateDeviceRequest.Meta.annotations:type_name -> mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry
+	36, // 37: mir_api.v1.UpdateDeviceRequest.Properties.desired:type_name -> google.protobuf.Struct
+	38, // 38: mir_api.v1.UpdateDeviceRequest.Status.last_hearthbeat:type_name -> mir_api.v1.Timestamp
+	27, // 39: mir_api.v1.UpdateDeviceRequest.Status.schema:type_name -> mir_api.v1.UpdateDeviceRequest.Schema
+	28, // 40: mir_api.v1.UpdateDeviceRequest.Status.properties:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime
+	38, // 41: mir_api.v1.UpdateDeviceRequest.Schema.last_schema_fetch:type_name -> mir_api.v1.Timestamp
+	31, // 42: mir_api.v1.UpdateDeviceRequest.PropertiesTime.desired:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry
+	32, // 43: mir_api.v1.UpdateDeviceRequest.PropertiesTime.reported:type_name -> mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry
+	39, // 44: mir_api.v1.UpdateDeviceRequest.Meta.LabelsEntry.value:type_name -> mir_api.v1.OptString
+	39, // 45: mir_api.v1.UpdateDeviceRequest.Meta.AnnotationsEntry.value:type_name -> mir_api.v1.OptString
+	38, // 46: mir_api.v1.UpdateDeviceRequest.PropertiesTime.DesiredEntry.value:type_name -> mir_api.v1.Timestamp
+	38, // 47: mir_api.v1.UpdateDeviceRequest.PropertiesTime.ReportedEntry.value:type_name -> mir_api.v1.Timestamp
+	38, // 48: mir_api.v1.PropertiesTime.DesiredEntry.value:type_name -> mir_api.v1.Timestamp
+	38, // 49: mir_api.v1.PropertiesTime.ReportedEntry.value:type_name -> mir_api.v1.Timestamp
+	50, // [50:50] is the sub-list for method output_type
+	50, // [50:50] is the sub-list for method input_type
+	50, // [50:50] is the sub-list for extension type_name
+	50, // [50:50] is the sub-list for extension extendee
+	0,  // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_mir_api_v1_core_proto_init() }
@@ -1963,33 +2135,41 @@ func file_mir_api_v1_core_proto_init() {
 		return
 	}
 	file_mir_api_v1_common_proto_init()
+	file_mir_api_v1_core_proto_msgTypes[1].OneofWrappers = []any{
+		(*CreateDeviceResponse_Ok)(nil),
+		(*CreateDeviceResponse_Error)(nil),
+	}
 	file_mir_api_v1_core_proto_msgTypes[3].OneofWrappers = []any{
+		(*CreateDevicesResponse_Ok)(nil),
+		(*CreateDevicesResponse_Error)(nil),
+	}
+	file_mir_api_v1_core_proto_msgTypes[5].OneofWrappers = []any{
 		(*UpdateDeviceResponse_Ok)(nil),
 		(*UpdateDeviceResponse_Error)(nil),
 	}
-	file_mir_api_v1_core_proto_msgTypes[5].OneofWrappers = []any{
+	file_mir_api_v1_core_proto_msgTypes[7].OneofWrappers = []any{
 		(*MergeDeviceResponse_Ok)(nil),
 		(*MergeDeviceResponse_Error)(nil),
 	}
-	file_mir_api_v1_core_proto_msgTypes[7].OneofWrappers = []any{
+	file_mir_api_v1_core_proto_msgTypes[9].OneofWrappers = []any{
 		(*DeleteDeviceResponse_Ok)(nil),
 		(*DeleteDeviceResponse_Error)(nil),
 	}
-	file_mir_api_v1_core_proto_msgTypes[9].OneofWrappers = []any{
+	file_mir_api_v1_core_proto_msgTypes[11].OneofWrappers = []any{
 		(*ListDeviceResponse_Ok)(nil),
 		(*ListDeviceResponse_Error)(nil),
 	}
-	file_mir_api_v1_core_proto_msgTypes[21].OneofWrappers = []any{}
-	file_mir_api_v1_core_proto_msgTypes[22].OneofWrappers = []any{}
+	file_mir_api_v1_core_proto_msgTypes[23].OneofWrappers = []any{}
 	file_mir_api_v1_core_proto_msgTypes[24].OneofWrappers = []any{}
-	file_mir_api_v1_core_proto_msgTypes[25].OneofWrappers = []any{}
+	file_mir_api_v1_core_proto_msgTypes[26].OneofWrappers = []any{}
+	file_mir_api_v1_core_proto_msgTypes[27].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mir_api_v1_core_proto_rawDesc), len(file_mir_api_v1_core_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkgs/api/proto/mir_api/v1/core.proto
+++ b/pkgs/api/proto/mir_api/v1/core.proto
@@ -9,12 +9,7 @@ import "mir_api/v1/common.proto";
   Send a request to create a new device in the system
 */
 message CreateDeviceRequest {
-    repeated Device devices = 1; // Represent the specifications that can be updated
-
-    message Device {
-        Meta meta = 1; // Represent the specifications that can be updated
-        DeviceSpec spec = 2; // Represent device twin specific config from Mir
-    }
+    NewDevice device = 1; // Represent the specifications that can be updated
 }
 
 /*
@@ -22,8 +17,28 @@ message CreateDeviceRequest {
   Only the error or the response data will be set
 */
 message CreateDeviceResponse {
-    DeviceList ok = 1; // devices that were created
-    string error = 2; // Error message if troubleshooting is needed
+    oneof response {
+        Device ok = 1; // device that were created
+        string error = 2; // Error message if troubleshooting is needed
+    }
+}
+
+/*
+  Send a request to create a new device in the system
+*/
+message CreateDevicesRequest {
+    repeated NewDevice devices = 1; // Represent the specifications that can be updated
+}
+
+/*
+  Response to multiple create device request
+  Only the error or the response data will be set
+*/
+message CreateDevicesResponse {
+    oneof response {
+        DeviceList ok = 1; // devices that were created
+        string error = 2; // Error message if troubleshooting is needed
+    }
 }
 
 /*
@@ -166,6 +181,11 @@ message Device {
   DeviceSpec spec = 4; // Represent device twin specific config from Mir
   DeviceProperties properties = 5; // Represent set of device defined properties
   DeviceStatus status = 6; // Represent the status reported by the Mir
+}
+
+message NewDevice {
+    Meta meta = 1; // Represent the specifications that can be updated
+    DeviceSpec spec = 2; // Represent device twin specific config from Mir
 }
 
 /*

--- a/pkgs/mir_v1/transform.go
+++ b/pkgs/mir_v1/transform.go
@@ -24,6 +24,15 @@ func NewDeviceListFromProtoDevices(d []*mir_apiv1.Device) []Device {
 	return p
 }
 
+func NewDeviceCreatedFromProtoDevices(d []*mir_apiv1.Device) []Device {
+	p := []Device{}
+	for _, v := range d {
+		dev := NewDeviceFromProtoDevice(v)
+		p = append(p, dev)
+	}
+	return p
+}
+
 func NewDeviceFromProtoDevice(d *mir_apiv1.Device) Device {
 	dev := NewDevice()
 	if d == nil {
@@ -334,8 +343,8 @@ func NewDeviceFromUpdateDeviceReq(d *mir_apiv1.UpdateDeviceRequest) Device {
 	return dev
 }
 
-func NewCreateDeviceReqFromDevice(d Device) *mir_apiv1.CreateDeviceRequest_Device {
-	return &mir_apiv1.CreateDeviceRequest_Device{
+func NewCreateDeviceReqFromDevice(d Device) *mir_apiv1.NewDevice {
+	return &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Name:        d.Meta.Name,
 			Namespace:   d.Meta.Namespace,
@@ -349,10 +358,10 @@ func NewCreateDeviceReqFromDevice(d Device) *mir_apiv1.CreateDeviceRequest_Devic
 	}
 }
 
-func NewCreateDeviceReqFromDevices(d []Device) *mir_apiv1.CreateDeviceRequest {
-	req := &mir_apiv1.CreateDeviceRequest{}
+func NewCreateDeviceReqFromDevices(d []Device) []*mir_apiv1.NewDevice {
+	req := []*mir_apiv1.NewDevice{}
 	for _, dev := range d {
-		req.Devices = append(req.Devices, NewCreateDeviceReqFromDevice(dev))
+		req = append(req, NewCreateDeviceReqFromDevice(dev))
 	}
 	return req
 }
@@ -416,7 +425,7 @@ func DeviceToUpdateDeviceRequest(d Device) *mir_apiv1.UpdateDeviceRequest {
 	return devUpd
 }
 
-func NewCreateDeviceReqFromDeviceUpdateRequest(d *mir_apiv1.UpdateDeviceRequest) *mir_apiv1.CreateDeviceRequest {
+func NewCreateDeviceReqFromDeviceUpdateRequest(d *mir_apiv1.UpdateDeviceRequest) []*mir_apiv1.NewDevice {
 	toMap := func(m map[string]*mir_apiv1.OptString) map[string]string {
 		opt := map[string]string{}
 		for k, v := range m {
@@ -426,7 +435,7 @@ func NewCreateDeviceReqFromDeviceUpdateRequest(d *mir_apiv1.UpdateDeviceRequest)
 		}
 		return opt
 	}
-	dev := &mir_apiv1.CreateDeviceRequest_Device{
+	dev := &mir_apiv1.NewDevice{
 		Meta: &mir_apiv1.Meta{
 			Labels:      toMap(d.Meta.Labels),
 			Annotations: toMap(d.Meta.Annotations),
@@ -449,23 +458,21 @@ func NewCreateDeviceReqFromDeviceUpdateRequest(d *mir_apiv1.UpdateDeviceRequest)
 			dev.Spec.Disabled = *d.Spec.Disabled
 		}
 	}
-	return &mir_apiv1.CreateDeviceRequest{
-		Devices: []*mir_apiv1.CreateDeviceRequest_Device{dev},
-	}
+	return []*mir_apiv1.NewDevice{dev}
 }
 
-func NewDevicesFromCreateDeviceReq(d *mir_apiv1.CreateDeviceRequest) []Device {
+func NewDevicesFromCreateDeviceReq(d []*mir_apiv1.NewDevice) []Device {
 	if d == nil {
 		return []Device{}
 	}
 	devs := []Device{}
-	for _, dev := range d.Devices {
+	for _, dev := range d {
 		devs = append(devs, NewDeviceFromCreateDeviceReq(dev))
 	}
 	return devs
 }
 
-func NewDeviceFromCreateDeviceReq(d *mir_apiv1.CreateDeviceRequest_Device) Device {
+func NewDeviceFromCreateDeviceReq(d *mir_apiv1.NewDevice) Device {
 	return Device{
 		Object: Object{
 			ApiVersion: "mir/v1alpha",

--- a/pkgs/module/mir/server_core.go
+++ b/pkgs/module/mir/server_core.go
@@ -112,37 +112,50 @@ func (r *clientRoutes) CreateDevice() *createDeviceRoute {
 }
 
 // Subscribe to createDevice routes
-func (r *createDeviceRoute) Subscribe(f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) error {
+func (r *createDeviceRoute) Subscribe(f func(msg *Msg, clientId string, d mir_v1.Device) (mir_v1.Device, error)) error {
 	sbj := core_client.CreateDeviceRequest.WithId("*")
 	return r.m.subscribe(sbj, r.handlerWrapper(f))
 }
 
 // Queue subscribe to createDevice routes
-func (r *createDeviceRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) error {
+func (r *createDeviceRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, d mir_v1.Device) (mir_v1.Device, error)) error {
 	sbj := core_client.CreateDeviceRequest.WithId("*")
 	return r.m.queueSubscribe(queue, sbj, r.handlerWrapper(f))
 }
 
-func (r *createDeviceRoute) handlerWrapper(f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) nats.MsgHandler {
+func (r *createDeviceRoute) handlerWrapper(f func(msg *Msg, clientId string, d mir_v1.Device) (mir_v1.Device, error)) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		req := &mir_apiv1.CreateDeviceRequest{}
 		if err := proto.Unmarshal(msg.Data, req); err != nil {
 			// TODO log error here
-			_ = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{Error: err.Error()})
+			_ = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{
+				Response: &mir_apiv1.CreateDeviceResponse_Error{
+					Error: err.Error(),
+				},
+			})
 			return
 		}
 
-		resp, err := f(&Msg{msg}, clients.ClientSubject(msg.Subject).GetId(), mir_v1.NewDevicesFromCreateDeviceReq(req))
-		var strErr string
+		resp, err := f(&Msg{msg}, clients.ClientSubject(msg.Subject).GetId(), mir_v1.NewDeviceFromCreateDeviceReq(req.Device))
 		if err != nil {
-			strErr = err.Error()
+			err = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{
+				Response: &mir_apiv1.CreateDeviceResponse_Error{
+					Error: err.Error(),
+				},
+			})
+			return
 		}
 		err = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{
-			Error: strErr,
-			Ok:    &mir_apiv1.DeviceList{Devices: mir_v1.NewProtoDeviceListFromDevices(resp)},
+			Response: &mir_apiv1.CreateDeviceResponse_Ok{
+				Ok: mir_v1.NewProtoDeviceFromDevice(resp),
+			},
 		})
 		if err != nil {
-			_ = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{Error: err.Error()})
+			_ = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDeviceResponse{
+				Response: &mir_apiv1.CreateDeviceResponse_Error{
+					Error: err.Error(),
+				},
+			})
 		}
 	}
 }
@@ -150,8 +163,8 @@ func (r *createDeviceRoute) handlerWrapper(f func(msg *Msg, clientId string, d [
 // Request creation of a new device
 func (r *createDeviceRoute) Request(d mir_v1.Device) (mir_v1.Device, error) {
 	sbj := core_client.CreateDeviceRequest.WithId(r.m.GetInstanceName())
-	req := mir_v1.NewCreateDeviceReqFromDevices([]mir_v1.Device{d})
-	bReq, err := proto.Marshal(req)
+	req := mir_v1.NewCreateDeviceReqFromDevice(d)
+	bReq, err := proto.Marshal(&mir_apiv1.CreateDeviceRequest{Device: req})
 	if err != nil {
 		return mir_v1.Device{}, err
 	}
@@ -166,42 +179,103 @@ func (r *createDeviceRoute) Request(d mir_v1.Device) (mir_v1.Device, error) {
 	if err != nil {
 		return mir_v1.Device{}, err
 	}
-	if resp.GetError() != "" {
-		err = errors.New(resp.GetError())
-	}
-
-	if resp.GetOk() == nil || len(resp.GetOk().Devices) == 0 {
-		return mir_v1.Device{}, err
-	}
-
-	return mir_v1.NewDeviceListFromProtoDevices(resp.GetOk().Devices)[0], err
-}
-
-// Request creation of a new device
-func (r *createDeviceRoute) RequestMany(d []mir_v1.Device) ([]mir_v1.Device, error) {
-	sbj := core_client.CreateDeviceRequest.WithId(r.m.GetInstanceName())
-	req := mir_v1.NewCreateDeviceReqFromDevices(d)
-	bReq, err := proto.Marshal(req)
-	if err != nil {
-		return []mir_v1.Device{}, err
-	}
-
-	resMsg, err := r.m.request(sbj, bReq, nil, defaultTimeout)
-	if err != nil {
-		return []mir_v1.Device{}, err
-	}
-
-	resp := &mir_apiv1.CreateDeviceResponse{}
-	err = proto.Unmarshal(resMsg.Data, resp)
-	if err != nil {
-		return []mir_v1.Device{}, err
-	}
-
 	if resp.GetError() != "" {
 		err = errors.New(resp.GetError())
 	}
 
 	if resp.GetOk() == nil {
+		return mir_v1.Device{}, err
+	}
+
+	return mir_v1.NewDeviceFromProtoDevice(resp.GetOk()), err
+}
+
+/// CreateDevices
+
+type createDevicesRoute struct {
+	m *Mir
+}
+
+// CreateDevice to integrate a new device in the system
+func (r *clientRoutes) CreateDevices() *createDevicesRoute {
+	return &createDevicesRoute{m: r.m}
+}
+
+// Subscribe to createDevice routes
+func (r *createDevicesRoute) Subscribe(f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) error {
+	sbj := core_client.CreateDevicesRequest.WithId("*")
+	return r.m.subscribe(sbj, r.handlerWrapper(f))
+}
+
+// Queue subscribe to createDevice routes
+func (r *createDevicesRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) error {
+	sbj := core_client.CreateDevicesRequest.WithId("*")
+	return r.m.queueSubscribe(queue, sbj, r.handlerWrapper(f))
+}
+
+func (r *createDevicesRoute) handlerWrapper(f func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error)) nats.MsgHandler {
+	return func(msg *nats.Msg) {
+		req := &mir_apiv1.CreateDevicesRequest{}
+		if err := proto.Unmarshal(msg.Data, req); err != nil {
+			// TODO log error here
+			_ = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDevicesResponse{
+				Response: &mir_apiv1.CreateDevicesResponse_Error{
+					Error: err.Error(),
+				},
+			})
+			return
+		}
+
+		resp, err := f(&Msg{msg}, clients.ClientSubject(msg.Subject).GetId(), mir_v1.NewDevicesFromCreateDeviceReq(req.Devices))
+		if err != nil {
+			err = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDevicesResponse{
+				Response: &mir_apiv1.CreateDevicesResponse_Error{
+					Error: err.Error(),
+				},
+			})
+		}
+		err = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDevicesResponse{
+			Response: &mir_apiv1.CreateDevicesResponse_Ok{
+				Ok: &mir_apiv1.DeviceList{Devices: mir_v1.NewProtoDeviceListFromDevices(resp)},
+			},
+		})
+		if err != nil {
+			err = r.m.sendReplyOrAck(msg, &mir_apiv1.CreateDevicesResponse{
+				Response: &mir_apiv1.CreateDevicesResponse_Error{
+					Error: err.Error(),
+				},
+			})
+		}
+	}
+}
+
+// Request creation of a new device
+func (r *createDevicesRoute) Request(d []mir_v1.Device) ([]mir_v1.Device, error) {
+	sbj := core_client.CreateDevicesRequest.WithId(r.m.GetInstanceName())
+	req := mir_v1.NewCreateDeviceReqFromDevices(d)
+	bReq, err := proto.Marshal(&mir_apiv1.CreateDevicesRequest{
+		Devices: req,
+	})
+	if err != nil {
+		return []mir_v1.Device{}, err
+	}
+
+	resMsg, err := r.m.request(sbj, bReq, nil, defaultTimeout)
+	if err != nil {
+		return []mir_v1.Device{}, err
+	}
+
+	resp := &mir_apiv1.CreateDevicesResponse{}
+	err = proto.Unmarshal(resMsg.Data, resp)
+	if err != nil {
+		return []mir_v1.Device{}, err
+	}
+
+	if resp.GetError() != "" {
+		err = errors.New(resp.GetError())
+	}
+
+	if resp.GetOk() == nil && len(resp.GetOk().Devices) > 0 {
 		return []mir_v1.Device{}, err
 	}
 

--- a/pkgs/module/mir/server_integration_test.go
+++ b/pkgs/module/mir/server_integration_test.go
@@ -103,8 +103,8 @@ func TestServerRoutes_CreateDevice(t *testing.T) {
 		})
 
 	err := m.Client().CreateDevice().Subscribe(
-		func(msg *Msg, clientId string, d []mir_v1.Device) ([]mir_v1.Device, error) {
-			return []mir_v1.Device{mir_v1.NewDevice().WithMeta(
+		func(msg *Msg, clientId string, d mir_v1.Device) (mir_v1.Device, error) {
+			return mir_v1.NewDevice().WithMeta(
 				mir_v1.Meta{
 					Name:      testDevice.Meta.Name,
 					Namespace: testDevice.Meta.Namespace,
@@ -112,7 +112,7 @@ func TestServerRoutes_CreateDevice(t *testing.T) {
 				mir_v1.DeviceSpec{
 					DeviceId: testDevice.Spec.DeviceId,
 				},
-			)}, nil
+			), nil
 		})
 	assert.NilError(t, err)
 

--- a/scripts/clean_db.sh
+++ b/scripts/clean_db.sh
@@ -13,6 +13,10 @@ while true; do
     done
 done
 
+# Sleep cause the deletion of devices create additional events
+# that we also want to delete
+sleep 3
+
 while true; do
     namespaces=$($bin event list -o json --limit 1000 | sed -n 's/.*"namespace": "\([^"]*\)".*/\1/p' | sort -u)
     if [ -z "$namespaces" ]; then


### PR DESCRIPTION
Split CreateDeviceRequest into two distinct endpoints:
- CreateDeviceRequest for single device creation
- CreateDevicesRequest for bulk device creation

This improves API clarity, error handling, and performance by optimizing each operation for its specific use case. Updated all integration tests, swarm library, and test utilities to use the new API structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Brief description of the changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Testing Done
<!-- Describe the testing you've done -->
- [ ] Manual tests
- [ ] Automated tests added
- [ ] No tests required

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues here using #issue-number -->
Closes #
