### PR TITLE
feat(tui): Add command interface for device management

### DIFF
--- a/internal/servers/protocfg_srv/server.go
+++ b/internal/servers/protocfg_srv/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/maxthom/mir/internal/libs/api/metrics"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/json_template"
+	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
 	devicev1 "github.com/maxthom/mir/pkgs/device/gen/proto/mir/device/v1"
@@ -135,7 +136,14 @@ func (s *ProtoCfgServer) Shutdown() error {
 	return nil
 }
 
-func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error) {
+type schemaPerDevices struct {
+	sch        *mir_proto.MirProtoSchema
+	err        error
+	devsId     []string
+	devsNameNs []string
+}
+
+func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListConfigRequest) ([]*mir_apiv1.DevicesConfigs, error) {
 	l.Info().Any("req", req).Msg("list config request")
 	requestTotal.WithLabelValues("list").Inc()
 	degradedMode := false
@@ -162,7 +170,8 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 		}
 	}
 
-	devsCmds := make(map[string]*mir_apiv1.Configs)
+	devsCfg := []*mir_apiv1.DevicesConfigs{}
+	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
 		nameNs := dev.GetNameNamespace()
 		if degradedMode {
@@ -170,43 +179,101 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 		}
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
-			devsCmds[nameNs] = &mir_apiv1.Configs{
-				Error: err.Error(),
+			found := false
+			for _, d := range devsCfg {
+				if d.Error == err.Error() {
+					d.DevicesNamens = append(d.DevicesNamens, nameNs)
+					found = true
+				}
+			}
+			if !found {
+				devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
+					DevicesNamens: []string{nameNs},
+					Error:         err.Error(),
+				})
 			}
 			continue
 		}
-
-		cfgs, err := reg.GetConfigList(req.FilterLabels)
-		if err != nil {
-			devsCmds[nameNs] = &mir_apiv1.Configs{
-				Error: err.Error(),
+		found := false
+		for _, sch := range devSchemas {
+			if mir_proto.AreSchemaEqual(sch.sch, reg) {
+				sch.devsId = append(sch.devsId, dev.Spec.DeviceId)
+				sch.devsNameNs = append(sch.devsNameNs, nameNs)
+				found = true
 			}
-			continue
-		}
 
-		cfgList := []*mir_apiv1.ConfigDescriptor{}
-		for _, cfg := range cfgs {
-			if v, ok := dev.Properties.Desired[cfg.Name]; ok {
-				b, err := json.Marshal(v)
-				if err != nil {
-					cfg.Error = err.Error()
-				} else {
-					cfg.Values = string(b)
-				}
-			} else {
-				if degradedMode {
-					cfg.Values = errors.New("{\"err\": \"can't retrieve config in degraded mode\"}").Error()
-				}
-			}
-			cfgList = append(cfgList, cfg)
 		}
-		devsCmds[nameNs] = &mir_apiv1.Configs{
-			Configs: cfgList,
+		if !found {
+			devSchemas = append(devSchemas, &schemaPerDevices{
+				sch:        reg,
+				devsId:     []string{dev.Spec.DeviceId},
+				devsNameNs: []string{nameNs},
+			})
 		}
 	}
 
+	for _, sch := range devSchemas {
+		cmds, err := sch.sch.GetConfigList(req.FilterLabels)
+		if err != nil {
+			devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
+				DevicesNamens: sch.devsNameNs,
+				Error:         err.Error(),
+			})
+			requestErrorTotal.WithLabelValues("list").Inc()
+			continue
+		}
+
+		devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
+			DevicesNamens:  sch.devsNameNs,
+			CfgDescriptors: cmds,
+		})
+	}
+
+	// devsCmds := make(map[string]*mir_apiv1.Configs)
+	// for _, dev := range devs {
+	// 	nameNs := dev.GetNameNamespace()
+	// 	if degradedMode {
+	// 		nameNs = dev.Spec.DeviceId
+	// 	}
+	// 	reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
+	// 	if err != nil {
+	// 		devsCmds[nameNs] = &mir_apiv1.Configs{
+	// 			Error: err.Error(),
+	// 		}
+	// 		continue
+	// 	}
+
+	// 	cfgs, err := reg.GetConfigList(req.FilterLabels)
+	// 	if err != nil {
+	// 		devsCmds[nameNs] = &mir_apiv1.Configs{
+	// 			Error: err.Error(),
+	// 		}
+	// 		continue
+	// 	}
+
+	// 	cfgList := []*mir_apiv1.ConfigDescriptor{}
+	// 	for _, cfg := range cfgs {
+	// 		if v, ok := dev.Properties.Desired[cfg.Name]; ok {
+	// 			b, err := json.Marshal(v)
+	// 			if err != nil {
+	// 				cfg.Error = err.Error()
+	// 			} else {
+	// 				cfg.Values = string(b)
+	// 			}
+	// 		} else {
+	// 			if degradedMode {
+	// 				cfg.Values = errors.New("{\"err\": \"can't retrieve config in degraded mode\"}").Error()
+	// 			}
+	// 		}
+	// 		cfgList = append(cfgList, cfg)
+	// 	}
+	// 	devsCmds[nameNs] = &mir_apiv1.Configs{
+	// 		Configs: cfgList,
+	// 	}
+	// }
+
 	l.Info().Msg("list config request processed successfully")
-	return devsCmds, nil
+	return devsCfg, nil
 }
 
 func (s *ProtoCfgServer) sendConfigSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendConfigRequest) (*mir_apiv1.SendConfigResponse_ConfigResponses, error) {

--- a/internal/servers/protocfg_srv/server.go
+++ b/internal/servers/protocfg_srv/server.go
@@ -156,7 +156,7 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 	if err != nil {
 		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 			degradedMode = true
-			if !t.HasOnlyIdsTarget() {
+			if !t.HasOnlyIdsTarget() && degradedMode {
 				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
 			}
 			devs = []mir_v1.Device{}
@@ -174,21 +174,21 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
 		nameNs := dev.GetNameNamespace()
-		if degradedMode {
-			nameNs = dev.Spec.DeviceId
-		}
+		id := dev.Spec.DeviceId
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
 			found := false
 			for _, d := range devsCfg {
 				if d.Error == err.Error() {
 					d.DevicesNamens = append(d.DevicesNamens, nameNs)
+					d.DevicesId = append(d.DevicesId, nameNs)
 					found = true
 				}
 			}
 			if !found {
 				devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
 					DevicesNamens: []string{nameNs},
+					DevicesId:     []string{id},
 					Error:         err.Error(),
 				})
 			}
@@ -217,6 +217,7 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 		if err != nil {
 			devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
 				DevicesNamens: sch.devsNameNs,
+				DevicesId:     sch.devsId,
 				Error:         err.Error(),
 			})
 			requestErrorTotal.WithLabelValues("list").Inc()
@@ -225,52 +226,10 @@ func (s *ProtoCfgServer) listCfgSub(msg *mir.Msg, clientId string, req *mir_apiv
 
 		devsCfg = append(devsCfg, &mir_apiv1.DevicesConfigs{
 			DevicesNamens:  sch.devsNameNs,
+			DevicesId:      sch.devsId,
 			CfgDescriptors: cmds,
 		})
 	}
-
-	// devsCmds := make(map[string]*mir_apiv1.Configs)
-	// for _, dev := range devs {
-	// 	nameNs := dev.GetNameNamespace()
-	// 	if degradedMode {
-	// 		nameNs = dev.Spec.DeviceId
-	// 	}
-	// 	reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
-	// 	if err != nil {
-	// 		devsCmds[nameNs] = &mir_apiv1.Configs{
-	// 			Error: err.Error(),
-	// 		}
-	// 		continue
-	// 	}
-
-	// 	cfgs, err := reg.GetConfigList(req.FilterLabels)
-	// 	if err != nil {
-	// 		devsCmds[nameNs] = &mir_apiv1.Configs{
-	// 			Error: err.Error(),
-	// 		}
-	// 		continue
-	// 	}
-
-	// 	cfgList := []*mir_apiv1.ConfigDescriptor{}
-	// 	for _, cfg := range cfgs {
-	// 		if v, ok := dev.Properties.Desired[cfg.Name]; ok {
-	// 			b, err := json.Marshal(v)
-	// 			if err != nil {
-	// 				cfg.Error = err.Error()
-	// 			} else {
-	// 				cfg.Values = string(b)
-	// 			}
-	// 		} else {
-	// 			if degradedMode {
-	// 				cfg.Values = errors.New("{\"err\": \"can't retrieve config in degraded mode\"}").Error()
-	// 			}
-	// 		}
-	// 		cfgList = append(cfgList, cfg)
-	// 	}
-	// 	devsCmds[nameNs] = &mir_apiv1.Configs{
-	// 		Configs: cfgList,
-	// 	}
-	// }
 
 	l.Info().Msg("list config request processed successfully")
 	return devsCfg, nil

--- a/internal/servers/protocfg_srv/server_integration_test.go
+++ b/internal/servers/protocfg_srv/server_integration_test.go
@@ -112,19 +112,19 @@ func TestPublishCfgListRequest(t *testing.T) {
 	}
 
 	// Assert
-	dev := respListCfg.GetOk().DeviceConfigs[id+"/testing_cfg"]
-	assert.Equal(t, dev.Error, "")
-	assert.Equal(t, len(dev.Configs), 4)
-	assert.Equal(t, dev.Configs[0].Name, "protocfg_test.v1.Conduit")
-	assert.Equal(t, dev.Configs[0].Labels["building"], "A")
-	assert.Equal(t, dev.Configs[0].Labels["floor"], "1")
-	assert.Equal(t, dev.Configs[1].Name, "protocfg_test.v1.PowerLevel")
-	assert.Equal(t, dev.Configs[1].Labels["building"], "A")
-	assert.Equal(t, dev.Configs[1].Labels["floor"], "2")
-	assert.Equal(t, dev.Configs[2].Name, "protocfg_test.v1.Coordinate")
-	assert.Equal(t, len(dev.Configs[2].Labels), 0)
-	assert.Equal(t, dev.Configs[3].Name, "protocfg_test.v1.Destination")
-	assert.Equal(t, len(dev.Configs[3].Labels), 0)
+	dev := respListCfg.GetOk().DeviceConfigs[0].CfgDescriptors
+	assert.Equal(t, dev[0].Error, "")
+	assert.Equal(t, len(dev), 4)
+	assert.Equal(t, dev[0].Name, "protocfg_test.v1.Conduit")
+	assert.Equal(t, dev[0].Labels["building"], "A")
+	assert.Equal(t, dev[0].Labels["floor"], "1")
+	assert.Equal(t, dev[1].Name, "protocfg_test.v1.PowerLevel")
+	assert.Equal(t, dev[1].Labels["building"], "A")
+	assert.Equal(t, dev[1].Labels["floor"], "2")
+	assert.Equal(t, dev[2].Name, "protocfg_test.v1.Coordinate")
+	assert.Equal(t, len(dev[2].Labels), 0)
+	assert.Equal(t, dev[3].Name, "protocfg_test.v1.Destination")
+	assert.Equal(t, len(dev[3].Labels), 0)
 
 	cancel()
 	for _, wg := range wgs {
@@ -177,12 +177,12 @@ func TestPublishCfgListFiltersRequest(t *testing.T) {
 
 	// Assert
 	fmt.Println(respListCmd)
-	dev := respListCmd.GetOk().DeviceConfigs[id+"/testing_cfg"]
+	dev := respListCmd.GetOk().DeviceConfigs[0]
 	assert.Equal(t, dev.Error, "")
-	assert.Equal(t, len(dev.Configs), 1)
-	assert.Equal(t, dev.Configs[0].Name, "protocfg_test.v1.PowerLevel")
-	assert.Equal(t, dev.Configs[0].Labels["building"], "A")
-	assert.Equal(t, dev.Configs[0].Labels["floor"], "2")
+	assert.Equal(t, len(dev.CfgDescriptors), 1)
+	assert.Equal(t, dev.CfgDescriptors[0].Name, "protocfg_test.v1.PowerLevel")
+	assert.Equal(t, dev.CfgDescriptors[0].Labels["building"], "A")
+	assert.Equal(t, dev.CfgDescriptors[0].Labels["floor"], "2")
 
 	cancel()
 	for _, wg := range wgs {

--- a/internal/servers/protocmd_srv/server.go
+++ b/internal/servers/protocmd_srv/server.go
@@ -398,7 +398,7 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 	if err != nil {
 		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 			degradedMode = true
-			if !t.HasOnlyIdsTarget() {
+			if !t.HasOnlyIdsTarget() && degradedMode {
 				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
 			}
 			devs = []mir_v1.Device{}
@@ -416,21 +416,21 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
 		nameNs := dev.GetNameNamespace()
-		if degradedMode {
-			nameNs = dev.Spec.DeviceId
-		}
+		id := dev.Spec.DeviceId
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
 			found := false
 			for _, d := range devsCmd {
 				if d.Error == err.Error() {
 					d.DevicesNamens = append(d.DevicesNamens, nameNs)
+					d.DevicesId = append(d.DevicesId, id)
 					found = true
 				}
 			}
 			if !found {
 				devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
 					DevicesNamens: []string{nameNs},
+					DevicesId:     []string{id},
 					Error:         err.Error(),
 				})
 			}
@@ -459,6 +459,7 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 		if err != nil {
 			devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
 				DevicesNamens: sch.devsNameNs,
+				DevicesId:     sch.devsId,
 				Error:         err.Error(),
 			})
 			requestErrorTotal.WithLabelValues("list").Inc()
@@ -467,6 +468,7 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 
 		devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
 			DevicesNamens:  sch.devsNameNs,
+			DevicesId:      sch.devsId,
 			CmdDescriptors: cmds,
 		})
 	}

--- a/internal/servers/protocmd_srv/server.go
+++ b/internal/servers/protocmd_srv/server.go
@@ -471,37 +471,6 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 		})
 	}
 
-	// devsCmds := make(map[string]*mir_apiv1.Commands)
-	// for _, dev := range devs {
-	// 	nameNs := dev.GetNameNamespace()
-	// 	if degradedMode {
-	// 		nameNs = dev.Spec.DeviceId
-	// 	}
-	// 	reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
-	// 	if err != nil {
-	// 		devsCmds[nameNs] = &mir_apiv1.Commands{
-	// 			Error: err.Error(),
-	// 		}
-	// 		continue
-	// 	}
-
-	// 	cmds, err := reg.GetCommandsList(req.FilterLabels)
-	// 	if err != nil {
-	// 		devsCmds[nameNs] = &mir_apiv1.Commands{
-	// 			Error: err.Error(),
-	// 		}
-	// 		continue
-	// 	}
-
-	// 	cmdsList := []*mir_apiv1.CommandDescriptor{}
-	// 	for _, cmd := range cmds {
-	// 		cmdsList = append(cmdsList, cmd)
-	// 	}
-	// 	devsCmds[nameNs] = &mir_apiv1.Commands{
-	// 		Commands: cmdsList,
-	// 	}
-	// }
-
 	l.Info().Msg("list command request processed successfully")
 	return devsCmd, nil
 }

--- a/internal/servers/protocmd_srv/server.go
+++ b/internal/servers/protocmd_srv/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/maxthom/mir/internal/libs/api/metrics"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
 	"github.com/maxthom/mir/internal/libs/proto/json_template"
+	"github.com/maxthom/mir/internal/libs/proto/mir_proto"
 	"github.com/maxthom/mir/internal/services/schema_cache"
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
 	devicev1 "github.com/maxthom/mir/pkgs/device/gen/proto/mir/device/v1"
@@ -377,7 +378,14 @@ func (s *ProtoCmdServer) sendCommandToDevices(msg *mir.Msg, req *mir_apiv1.SendC
 	return devResp, nil
 }
 
-func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error) {
+type schemaPerDevices struct {
+	sch        *mir_proto.MirProtoSchema
+	err        error
+	devsId     []string
+	devsNameNs []string
+}
+
+func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error) {
 	l.Info().Any("req", req).Msg("list command request")
 	requestTotal.WithLabelValues("list").Inc()
 	degradedMode := false
@@ -404,7 +412,8 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 		}
 	}
 
-	devsCmds := make(map[string]*mir_apiv1.Commands)
+	devsCmd := []*mir_apiv1.DevicesCommands{}
+	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
 		nameNs := dev.GetNameNamespace()
 		if degradedMode {
@@ -412,31 +421,89 @@ func (s *ProtoCmdServer) listCommandsSub(msg *mir.Msg, clientId string, req *mir
 		}
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
-			devsCmds[nameNs] = &mir_apiv1.Commands{
-				Error: err.Error(),
+			found := false
+			for _, d := range devsCmd {
+				if d.Error == err.Error() {
+					d.DevicesNamens = append(d.DevicesNamens, nameNs)
+					found = true
+				}
+			}
+			if !found {
+				devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
+					DevicesNamens: []string{nameNs},
+					Error:         err.Error(),
+				})
 			}
 			continue
 		}
-
-		cmds, err := reg.GetCommandsList(req.FilterLabels)
-		if err != nil {
-			devsCmds[nameNs] = &mir_apiv1.Commands{
-				Error: err.Error(),
+		found := false
+		for _, sch := range devSchemas {
+			if mir_proto.AreSchemaEqual(sch.sch, reg) {
+				sch.devsId = append(sch.devsId, dev.Spec.DeviceId)
+				sch.devsNameNs = append(sch.devsNameNs, nameNs)
+				found = true
 			}
-			continue
-		}
 
-		cmdsList := []*mir_apiv1.CommandDescriptor{}
-		for _, cmd := range cmds {
-			cmdsList = append(cmdsList, cmd)
 		}
-		devsCmds[nameNs] = &mir_apiv1.Commands{
-			Commands: cmdsList,
+		if !found {
+			devSchemas = append(devSchemas, &schemaPerDevices{
+				sch:        reg,
+				devsId:     []string{dev.Spec.DeviceId},
+				devsNameNs: []string{nameNs},
+			})
 		}
 	}
 
+	for _, sch := range devSchemas {
+		cmds, err := sch.sch.GetCommandsList(req.FilterLabels)
+		if err != nil {
+			devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
+				DevicesNamens: sch.devsNameNs,
+				Error:         err.Error(),
+			})
+			requestErrorTotal.WithLabelValues("list").Inc()
+			continue
+		}
+
+		devsCmd = append(devsCmd, &mir_apiv1.DevicesCommands{
+			DevicesNamens:  sch.devsNameNs,
+			CmdDescriptors: cmds,
+		})
+	}
+
+	// devsCmds := make(map[string]*mir_apiv1.Commands)
+	// for _, dev := range devs {
+	// 	nameNs := dev.GetNameNamespace()
+	// 	if degradedMode {
+	// 		nameNs = dev.Spec.DeviceId
+	// 	}
+	// 	reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
+	// 	if err != nil {
+	// 		devsCmds[nameNs] = &mir_apiv1.Commands{
+	// 			Error: err.Error(),
+	// 		}
+	// 		continue
+	// 	}
+
+	// 	cmds, err := reg.GetCommandsList(req.FilterLabels)
+	// 	if err != nil {
+	// 		devsCmds[nameNs] = &mir_apiv1.Commands{
+	// 			Error: err.Error(),
+	// 		}
+	// 		continue
+	// 	}
+
+	// 	cmdsList := []*mir_apiv1.CommandDescriptor{}
+	// 	for _, cmd := range cmds {
+	// 		cmdsList = append(cmdsList, cmd)
+	// 	}
+	// 	devsCmds[nameNs] = &mir_apiv1.Commands{
+	// 		Commands: cmdsList,
+	// 	}
+	// }
+
 	l.Info().Msg("list command request processed successfully")
-	return devsCmds, nil
+	return devsCmd, nil
 }
 
 func publishCommandEvent(m *mir.Mir, msg *mir.Msg, name, namespace string, cmd *mir_apiv1.SendCommandResponse_CommandResponse) error {

--- a/internal/servers/protocmd_srv/server_integration_test.go
+++ b/internal/servers/protocmd_srv/server_integration_test.go
@@ -109,19 +109,19 @@ func TestPublishCmdListRequest(t *testing.T) {
 	}
 
 	// Assert
-	dev := respListCmd.GetOk().DeviceCommands[id+"/testing_cmd"]
+	dev := respListCmd.GetOk().DevicesCommands[0]
 	assert.Equal(t, dev.Error, "")
-	assert.Equal(t, len(dev.Commands), 4)
-	assert.Equal(t, dev.Commands[0].Name, "protocmd_test.v1.Command")
-	assert.Equal(t, dev.Commands[0].Labels["building"], "A")
-	assert.Equal(t, dev.Commands[0].Labels["floor"], "1")
-	assert.Equal(t, dev.Commands[1].Name, "protocmd_test.v1.ChangePower")
-	assert.Equal(t, dev.Commands[1].Labels["building"], "A")
-	assert.Equal(t, dev.Commands[1].Labels["floor"], "2")
-	assert.Equal(t, dev.Commands[2].Name, "protocmd_test.v1.SetTargetVector")
-	assert.Equal(t, len(dev.Commands[2].Labels), 0)
-	assert.Equal(t, dev.Commands[3].Name, "protocmd_test.v1.SetDestination")
-	assert.Equal(t, len(dev.Commands[3].Labels), 0)
+	assert.Equal(t, len(dev.CmdDescriptors), 4)
+	assert.Equal(t, dev.CmdDescriptors[0].Name, "protocmd_test.v1.Command")
+	assert.Equal(t, dev.CmdDescriptors[0].Labels["building"], "A")
+	assert.Equal(t, dev.CmdDescriptors[0].Labels["floor"], "1")
+	assert.Equal(t, dev.CmdDescriptors[1].Name, "protocmd_test.v1.ChangePower")
+	assert.Equal(t, dev.CmdDescriptors[1].Labels["building"], "A")
+	assert.Equal(t, dev.CmdDescriptors[1].Labels["floor"], "2")
+	assert.Equal(t, dev.CmdDescriptors[2].Name, "protocmd_test.v1.SetTargetVector")
+	assert.Equal(t, len(dev.CmdDescriptors[2].Labels), 0)
+	assert.Equal(t, dev.CmdDescriptors[3].Name, "protocmd_test.v1.SetDestination")
+	assert.Equal(t, len(dev.CmdDescriptors[3].Labels), 0)
 
 	cancel()
 	for _, wg := range wgs {
@@ -173,12 +173,12 @@ func TestPublishCmdListFiltersRequest(t *testing.T) {
 	}
 
 	// Assert
-	dev := respListCmd.GetOk().DeviceCommands[id+"/testing_cmd"]
+	dev := respListCmd.GetOk().DevicesCommands[0]
 	assert.Equal(t, dev.Error, "")
-	assert.Equal(t, len(dev.Commands), 1)
-	assert.Equal(t, dev.Commands[0].Name, "protocmd_test.v1.ChangePower")
-	assert.Equal(t, dev.Commands[0].Labels["building"], "A")
-	assert.Equal(t, dev.Commands[0].Labels["floor"], "2")
+	assert.Equal(t, len(dev.CmdDescriptors), 1)
+	assert.Equal(t, dev.CmdDescriptors[0].Name, "protocmd_test.v1.ChangePower")
+	assert.Equal(t, dev.CmdDescriptors[0].Labels["building"], "A")
+	assert.Equal(t, dev.CmdDescriptors[0].Labels["floor"], "2")
 
 	cancel()
 	for _, wg := range wgs {

--- a/internal/servers/prototlm_srv/server.go
+++ b/internal/servers/prototlm_srv/server.go
@@ -226,7 +226,7 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 	if err != nil {
 		if strings.Contains(err.Error(), surreal.ErrDatabaseDisconnected.Error()) {
 			degradedMode = true
-			if !t.HasOnlyIdsTarget() {
+			if !t.HasOnlyIdsTarget() && degradedMode {
 				return nil, fmt.Errorf("running in degraded mode as database is disconnected, only device ids can be used")
 			}
 			devs = []mir_v1.Device{}
@@ -244,21 +244,21 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 	devSchemas := []*schemaPerDevices{}
 	for _, dev := range devs {
 		nameNs := dev.GetNameNamespace()
-		if degradedMode {
-			nameNs = dev.Spec.DeviceId
-		}
+		id := dev.Spec.DeviceId
 		reg, _, err := s.schStore.GetDeviceSchema(dev.Spec.DeviceId, req.RefreshSchema)
 		if err != nil {
 			found := false
 			for _, d := range devsTlm {
 				if d.Error == err.Error() {
 					d.DevicesNamens = append(d.DevicesNamens, nameNs)
+					d.DevicesId = append(d.DevicesId, id)
 					found = true
 				}
 			}
 			if !found {
 				devsTlm = append(devsTlm, &mir_apiv1.DevicesTelemetry{
 					DevicesNamens: []string{nameNs},
+					DevicesId:     []string{id},
 					Error:         err.Error(),
 				})
 			}
@@ -287,6 +287,7 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 		if err != nil {
 			devsTlm = append(devsTlm, &mir_apiv1.DevicesTelemetry{
 				DevicesNamens: sch.devsNameNs,
+				DevicesId:     sch.devsId,
 				Error:         err.Error(),
 			})
 			requestErrorTotal.WithLabelValues("list").Inc()
@@ -303,6 +304,7 @@ func (s *ProtoTlmServer) handleTelemetryListRequest(msg *mir.Msg, clientId strin
 		}
 		devsTlm = append(devsTlm, &mir_apiv1.DevicesTelemetry{
 			DevicesNamens:  sch.devsNameNs,
+			DevicesId:      sch.devsId,
 			TlmDescriptors: tlms,
 		})
 	}

--- a/internal/ui/cli/command_cmd.go
+++ b/internal/ui/cli/command_cmd.go
@@ -97,7 +97,11 @@ func (d *CommandListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) erro
 				}
 			}
 		}
-		tpls[sb.String()] = append(tpls[sb.String()], cmds.DevicesNamens...)
+		devsTitle := cmds.DevicesNamens
+		if len(cmds.DevicesNamens) > 3 {
+			devsTitle = []string{strings.Join(cmds.DevicesNamens[0:3], ", ") + " & " + fmt.Sprintf("%d more", len(cmds.DevicesNamens)-3)}
+		}
+		tpls[sb.String()] = append(tpls[sb.String()], devsTitle...)
 		sb.Reset()
 	}
 

--- a/internal/ui/cli/command_cmd.go
+++ b/internal/ui/cli/command_cmd.go
@@ -74,11 +74,11 @@ func (d *CommandListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) erro
 
 	tpls := map[string][]string{}
 	var sb strings.Builder
-	for devNameNs, cmds := range resp {
+	for _, cmds := range resp {
 		if cmds.Error != "" {
 			sb.WriteString(cmds.Error)
 		} else {
-			for _, cmd := range cmds.Commands {
+			for _, cmd := range cmds.CmdDescriptors {
 				sb.WriteString(cmd.Name)
 				sb.WriteString("{")
 				sb.WriteString(mapToSortedString(cmd.Labels))
@@ -97,7 +97,7 @@ func (d *CommandListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) erro
 				}
 			}
 		}
-		tpls[sb.String()] = append(tpls[sb.String()], devNameNs)
+		tpls[sb.String()] = append(tpls[sb.String()], cmds.DevicesNamens...)
 		sb.Reset()
 	}
 

--- a/internal/ui/cli/config_cmd.go
+++ b/internal/ui/cli/config_cmd.go
@@ -74,11 +74,11 @@ func (d *ConfigListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) error
 
 	tpls := map[string][]string{}
 	var sb strings.Builder
-	for devNameNs, cmds := range resp {
+	for _, cmds := range resp {
 		if cmds.Error != "" {
 			sb.WriteString(cmds.Error)
 		} else {
-			for _, cmd := range cmds.Configs {
+			for _, cmd := range cmds.CfgDescriptors {
 				sb.WriteString(cmd.Name)
 				sb.WriteString("{")
 				sb.WriteString(mapToSortedString(cmd.Labels))
@@ -101,7 +101,11 @@ func (d *ConfigListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) error
 				}
 			}
 		}
-		tpls[sb.String()] = append(tpls[sb.String()], devNameNs)
+		devsTitle := cmds.DevicesNamens
+		if len(cmds.DevicesNamens) > 3 {
+			devsTitle = []string{strings.Join(cmds.DevicesNamens[0:3], ", ") + " & " + fmt.Sprintf("%d more", len(cmds.DevicesNamens)-3)}
+		}
+		tpls[sb.String()] = append(tpls[sb.String()], devsTitle...)
 		sb.Reset()
 	}
 

--- a/internal/ui/cli/config_cmd.go
+++ b/internal/ui/cli/config_cmd.go
@@ -80,9 +80,9 @@ func (d *ConfigListCmd) Run(log zerolog.Logger, m *mir.Mir, cfg ui.Config) error
 		} else {
 			for _, cmd := range cmds.CfgDescriptors {
 				sb.WriteString(cmd.Name)
-				sb.WriteString("{")
-				sb.WriteString(mapToSortedString(cmd.Labels))
-				sb.WriteString("}\n")
+				// sb.WriteString("{")
+				// sb.WriteString(mapToSortedString(cmd.Labels))
+				// sb.WriteString("}\n")
 				if cmd.Error != "" {
 					sb.WriteString(cmd.Error)
 					sb.WriteString("\n")

--- a/internal/ui/parser.go
+++ b/internal/ui/parser.go
@@ -1,0 +1,1 @@
+package ui

--- a/internal/ui/tui/components/menu/menu.go
+++ b/internal/ui/tui/components/menu/menu.go
@@ -13,11 +13,16 @@ type (
 	OptionSelectedMsg struct {
 		Option OptionValue
 	}
+	CursorMovedMsg struct {
+		Position  int
+		Direction int
+	}
 )
 type Model struct {
-	cursor  int
-	choice  OptionValue
-	choices []Option
+	cursor    int
+	direction int
+	choice    OptionValue
+	choices   []Option
 }
 type OptionValue = string
 type Option struct {
@@ -46,17 +51,19 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "down", "j", "tab":
 			m.cursor++
+			m.direction = 1
 			if m.cursor >= len(m.choices) {
 				m.cursor = 0
 			}
-			return m, nil
+			return m, m.cursorMoved(m.cursor, m.direction)
 
 		case "up", "k", "shift+tab":
 			m.cursor--
+			m.direction = -1
 			if m.cursor < 0 {
 				m.cursor = len(m.choices) - 1
 			}
-			return m, nil
+			return m, m.cursorMoved(m.cursor, m.direction)
 		}
 	}
 	return m, nil
@@ -98,4 +105,25 @@ func (m Model) optionSelectedCmd(v OptionValue) tea.Cmd {
 			v,
 		}
 	}
+}
+
+func (m Model) cursorMoved(pos int, direction int) tea.Cmd {
+	return func() tea.Msg {
+		return CursorMovedMsg{
+			Position:  pos,
+			Direction: direction,
+		}
+	}
+}
+
+func (m Model) GetCursor() int {
+	return m.cursor
+}
+
+func (m Model) GetChoice() Option {
+	return m.choices[m.cursor]
+}
+
+func (m Model) GetDirection() int {
+	return m.direction
 }

--- a/internal/ui/tui/msgs/cmd.go
+++ b/internal/ui/tui/msgs/cmd.go
@@ -1,6 +1,8 @@
 package msgs
 
 import (
+	"encoding/json"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
@@ -10,6 +12,9 @@ import (
 type (
 	DeviceCommandListedMsg struct {
 		Commands []*mir_apiv1.DevicesCommands
+	}
+	DeviceCommandSentMsg struct {
+		CommandsResponse map[string]*mir_apiv1.SendCommandResponse_CommandResponse
 	}
 )
 
@@ -24,5 +29,29 @@ func listMirDeviceCommandsCmd(m *mir.Mir, t *mir_apiv1.DeviceTarget) func() tea.
 			return ErrMsg{Err: err}
 		}
 		return DeviceCommandListedMsg{Commands: list}
+	}
+}
+
+func SendMirDeviceCommands(m *mir.Mir, req *mir_apiv1.SendCommandRequest) tea.Cmd {
+	return sendMirDeviceCommandsCmd(m, req)
+}
+
+func SendMirDeviceCommandsRaw(m *mir.Mir, t *mir_apiv1.DeviceTarget, cmd string, payload json.RawMessage) tea.Cmd {
+	req := mir_apiv1.SendCommandRequest{
+		Name:            cmd,
+		Payload:         payload,
+		PayloadEncoding: mir_apiv1.Encoding_ENCODING_JSON,
+		Targets:         t,
+	}
+	return sendMirDeviceCommandsCmd(m, &req)
+}
+
+func sendMirDeviceCommandsCmd(m *mir.Mir, req *mir_apiv1.SendCommandRequest) func() tea.Msg {
+	return func() tea.Msg {
+		cmdResp, err := m.Client().SendCommand().Request(req)
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return DeviceCommandSentMsg{CommandsResponse: cmdResp}
 	}
 }

--- a/internal/ui/tui/msgs/cmd.go
+++ b/internal/ui/tui/msgs/cmd.go
@@ -1,0 +1,28 @@
+package msgs
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
+	"github.com/maxthom/mir/pkgs/module/mir"
+)
+
+type (
+	DeviceCommandListedMsg struct {
+		Commands []*mir_apiv1.DevicesCommands
+	}
+)
+
+func ListMirDeviceCommands(m *mir.Mir, t *mir_apiv1.DeviceTarget) tea.Cmd {
+	return listMirDeviceCommandsCmd(m, t)
+}
+
+func listMirDeviceCommandsCmd(m *mir.Mir, t *mir_apiv1.DeviceTarget) func() tea.Msg {
+	return func() tea.Msg {
+		list, err := m.Client().ListCommands().Request(&mir_apiv1.SendListCommandsRequest{Targets: t})
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return DeviceCommandListedMsg{Commands: list}
+	}
+}

--- a/internal/ui/tui/msgs/tui.go
+++ b/internal/ui/tui/msgs/tui.go
@@ -6,14 +6,28 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+var (
+	DefaultTimeout = 2 * time.Second
+)
+
 type (
-	ReqMsg string
-	ResMsg = string
+	ReqMsg struct {
+		Msg     string
+		Timeout time.Duration
+	}
+	ResMsg struct {
+		Msg     string
+		Timeout time.Duration
+	}
 	ErrMsg struct {
 		Err     error
 		Timeout time.Duration
 	}
 	RouteChangeMsg struct {
+		Route string
+		Data  any
+	}
+	RouteResumeMsg struct {
 		Route string
 		Data  any
 	}
@@ -44,14 +58,26 @@ func RouteChangeWithDataCmd(route string, data any) tea.Cmd {
 	}
 }
 
-func ReqMsgCmd(msg string) tea.Cmd {
+func RouteResume(route string) tea.Cmd {
 	return func() tea.Msg {
-		return ReqMsg(msg)
+		return RouteResumeMsg{Route: route, Data: nil}
 	}
 }
 
-func ResMsgCmd(msg string) tea.Cmd {
+func RouteResumeWithData(route string, data any) tea.Cmd {
 	return func() tea.Msg {
-		return ResMsg(msg)
+		return RouteResumeMsg{Route: route, Data: data}
+	}
+}
+
+func ReqMsgCmd(msg string, t time.Duration) tea.Cmd {
+	return func() tea.Msg {
+		return ReqMsg{msg, t}
+	}
+}
+
+func ResMsgCmd(msg string, t time.Duration) tea.Cmd {
+	return func() tea.Msg {
+		return ResMsg{msg, t}
 	}
 }

--- a/internal/ui/tui/pages/device/cmd/cmd.go
+++ b/internal/ui/tui/pages/device/cmd/cmd.go
@@ -1,0 +1,219 @@
+package device_commands
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/maxthom/mir/internal/libs/external/grafana"
+	"github.com/maxthom/mir/internal/ui/tui/components/group_menu"
+	mir_help "github.com/maxthom/mir/internal/ui/tui/components/help"
+	"github.com/maxthom/mir/internal/ui/tui/msgs"
+	device_list "github.com/maxthom/mir/internal/ui/tui/pages/device/list"
+	"github.com/maxthom/mir/internal/ui/tui/store"
+	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
+	"github.com/maxthom/mir/pkgs/mir_v1"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	l zerolog.Logger
+	v strings.Builder
+)
+
+const ()
+
+type Model struct {
+	ctx      context.Context
+	help     mir_help.Model
+	devices  []mir_v1.Device
+	commands []*mir_apiv1.DevicesCommands
+	menu     group_menu.Model
+}
+
+type InputData struct {
+}
+
+func NewModel(ctx context.Context) *Model {
+	l = log.With().Str("page", "device_tlm_list").Logger()
+
+	return &Model{
+		ctx:  ctx,
+		help: mir_help.New(keys, []string{}, "mir device commands"),
+		menu: group_menu.New(nil),
+	}
+}
+
+func (m *Model) InitWithData(d any) tea.Cmd {
+	devs, ok := d.([]mir_v1.Device)
+	if !ok {
+		return tea.Batch(
+			msgs.ErrCmd(fmt.Errorf("no device specified"), 2*time.Second),
+			msgs.RouteChangeWithDataCmd("/devices", device_list.InputData{SilentFetch: true}),
+		)
+	}
+	m.devices = devs
+
+	target := mir_apiv1.DeviceTarget{}
+	for _, d := range m.devices {
+		target.Ids = append(target.Ids, d.Spec.DeviceId)
+	}
+
+	return msgs.ListMirDeviceCommands(store.Bus, &target)
+}
+
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		msgs.ErrCmd(fmt.Errorf("no device specified"), 2*time.Second),
+		msgs.RouteChangeWithDataCmd("/devices", device_list.InputData{SilentFetch: true}),
+	)
+}
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case msgs.DeviceCommandListedMsg:
+		l.Debug().Int("count", len(msg.Commands)).Msg("received device commands list")
+		m.commands = msg.Commands
+		groupchoice := []group_menu.GroupChoice{}
+		l.Info().Any("test", m.commands).Msg("asd")
+		for _, cmd := range m.commands {
+			gc := group_menu.GroupChoice{
+				Choices: []group_menu.Option{},
+			}
+			if len(cmd.DevicesNamens) > 3 {
+				gc.Label = strings.Join(cmd.DevicesNamens[0:3], ", ") + " & " + strconv.Itoa(len(cmd.DevicesNamens)-3) + " more"
+			} else {
+				gc.Label = strings.Join(cmd.DevicesNamens, ", ")
+			}
+
+			if cmd.Error != "" {
+				gc.Choices = append(gc.Choices, group_menu.Option{
+					Label:       "error",
+					Description: cmd.Error,
+				})
+			} else if len(cmd.CmdDescriptors) > 0 {
+				var sb strings.Builder
+				for _, desc := range cmd.CmdDescriptors {
+					sb.Reset()
+					sb.WriteString("      ")
+					// sb.WriteString(strings.Join(desc.Fields, "\n      "))
+					gc.Choices = append(gc.Choices, group_menu.Option{
+						Label:       fmt.Sprintf("%s{%s}", desc.Name, mapToSortedString(desc.Labels)),
+						Description: desc.Error,
+						Value:       desc.Name,
+						Details:     sb.String(),
+					})
+				}
+			}
+			groupchoice = append(groupchoice, gc)
+		}
+		m.menu = group_menu.New(groupchoice)
+		return m, msgs.ResMsgCmd(fmt.Sprintf("%d commands fetched", len(msg.Commands)))
+	case msgs.EditorFinishedMsg:
+		return m, nil
+	case tea.KeyMsg:
+		m.help, cmd = m.help.Update(msg)
+		if msg.String() == "g" {
+			// i, j := m.menu.GetCursor()
+			tlmQuery := "" // m.commands[i].TlmDescriptors[j].ExploreQuery
+			if tlmQuery != "" {
+				if err := grafana.OpenBrowser(grafana.CreateExploreLink(store.MirCtx.Grafana, tlmQuery)); err != nil {
+					return m, msgs.ErrCmd(fmt.Errorf("failed to open grafana link: %w", err), 2*time.Second)
+				}
+			} else {
+				return m, msgs.ErrCmd(fmt.Errorf("no grafana query available for this telemetry"), 2*time.Second)
+			}
+		} else if msg.String() == "q" {
+			// i, j := m.menu.GetCursor()
+			tlmQuery := "" // km.telemetry[i].TlmDescriptors[j].ExploreQuery
+			if tlmQuery != "" {
+				return m, msgs.OpenEditorCmd(msgs.FileTypeYAML, []byte(tlmQuery), []string{})
+			}
+		} else {
+			m.menu, cmd = m.menu.Update(msg)
+		}
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *Model) View() string {
+	v.Reset()
+	v.WriteString("\n")
+
+	// q := ""
+	// i, j := m.menu.GetCursor()
+	// if len(m.telemetry) > i && len(m.telemetry[i].TlmDescriptors) > j {
+	// TODO in a future, the side panel will be a tlm chart
+	// q = m.telemetry[i].TlmDescriptors[j].ExploreQuery
+	// q = "{" + mapToSortedString(m.telemetry[i].TlmDescriptors[j].Labels) + "}\n"
+	// q += lipgloss.NewStyle().Bold(true).Render("Fields")
+	// q += "\n• " + strings.Join(m.telemetry[i].TlmDescriptors[j].Fields, "\n• ")
+	// q = styles.SidePanel.Render(q)
+	// }
+	// v.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, m.menu.View(), "          ", q))
+
+	v.WriteString(m.menu.View())
+	v.WriteString(m.help.View())
+	return v.String()
+}
+
+type keyMap map[string]key.Binding
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k["space"], k["grafana"], k["query"]}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k["space"], k["grafana"], k["query"]},
+	}
+}
+
+var keys = keyMap{
+	"space": key.NewBinding(
+		key.WithKeys(" "),
+		key.WithHelp("space", "fields"),
+	),
+	"grafana": key.NewBinding(
+		key.WithKeys("g"),
+		key.WithHelp("g", "grafana"),
+	),
+	"query": key.NewBinding(
+		key.WithKeys("q"),
+		key.WithHelp("q", "query"),
+	),
+}
+
+func mapToSortedString(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+
+	// Get sorted keys
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build sorted string
+	var sb strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(k)
+		sb.WriteString("=")
+		sb.WriteString(m[k])
+	}
+	return sb.String()
+}

--- a/internal/ui/tui/pages/device/cmd/cmd.go
+++ b/internal/ui/tui/pages/device/cmd/cmd.go
@@ -2,6 +2,7 @@ package device_commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/maxthom/mir/internal/libs/external/grafana"
 	"github.com/maxthom/mir/internal/ui/tui/components/group_menu"
 	mir_help "github.com/maxthom/mir/internal/ui/tui/components/help"
 	"github.com/maxthom/mir/internal/ui/tui/msgs"
@@ -27,7 +27,9 @@ var (
 	v strings.Builder
 )
 
-const ()
+const (
+	menuOption_device_command_response string = "/devices/commands/responses"
+)
 
 type Model struct {
 	ctx      context.Context
@@ -35,19 +37,20 @@ type Model struct {
 	devices  []mir_v1.Device
 	commands []*mir_apiv1.DevicesCommands
 	menu     group_menu.Model
+	readOnly bool
 }
 
 type InputData struct {
 }
 
 func NewModel(ctx context.Context) *Model {
-	l = log.With().Str("page", "device_tlm_list").Logger()
+	l = log.With().Str("page", "device_cmd_list").Logger()
 
 	return &Model{
-		ctx:  ctx,
-		help: mir_help.New(keys, []string{}, "mir device commands"),
-		menu: group_menu.New(nil),
-	}
+		ctx:      ctx,
+		help:     mir_help.New(keys, []string{}, "mir device commands"),
+		menu:     group_menu.New(nil),
+		readOnly: true}
 }
 
 func (m *Model) InitWithData(d any) tea.Cmd {
@@ -75,20 +78,32 @@ func (m *Model) Init() tea.Cmd {
 	)
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case msgs.DeviceCommandListedMsg:
-		l.Debug().Int("count", len(msg.Commands)).Msg("received device commands list")
 		m.commands = msg.Commands
 		groupchoice := []group_menu.GroupChoice{}
-		l.Info().Any("test", m.commands).Msg("asd")
 		for _, cmd := range m.commands {
 			gc := group_menu.GroupChoice{
 				Choices: []group_menu.Option{},
 			}
 			if len(cmd.DevicesNamens) > 3 {
 				gc.Label = strings.Join(cmd.DevicesNamens[0:3], ", ") + " & " + strconv.Itoa(len(cmd.DevicesNamens)-3) + " more"
+			} else if len(cmd.DevicesNamens) == 0 {
+				if len(cmd.DevicesId) > 3 {
+					gc.Label = strings.Join(cmd.DevicesId[0:3], ", ") + " & " + strconv.Itoa(len(cmd.DevicesId)-3) + " more"
+				} else {
+					gc.Label = strings.Join(cmd.DevicesId, ", ")
+				}
 			} else {
 				gc.Label = strings.Join(cmd.DevicesNamens, ", ")
 			}
@@ -102,10 +117,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				var sb strings.Builder
 				for _, desc := range cmd.CmdDescriptors {
 					sb.Reset()
-					sb.WriteString("      ")
-					// sb.WriteString(strings.Join(desc.Fields, "\n      "))
+					if len(desc.Labels) == 0 {
+						sb.WriteString("    {}")
+					} else {
+						sb.WriteString("    {\n      ")
+						sb.WriteString(mapToSortedString(desc.Labels, "\n      "))
+						sb.WriteString("\n    }")
+					}
 					gc.Choices = append(gc.Choices, group_menu.Option{
-						Label:       fmt.Sprintf("%s{%s}", desc.Name, mapToSortedString(desc.Labels)),
+						Label:       desc.Name,
 						Description: desc.Error,
 						Value:       desc.Name,
 						Details:     sb.String(),
@@ -115,27 +135,53 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			groupchoice = append(groupchoice, gc)
 		}
 		m.menu = group_menu.New(groupchoice)
-		return m, msgs.ResMsgCmd(fmt.Sprintf("%d commands fetched", len(msg.Commands)))
+		return m, msgs.ResMsgCmd(fmt.Sprintf("%d commands fetched", len(msg.Commands)), msgs.DefaultTimeout)
 	case msgs.EditorFinishedMsg:
-		return m, nil
+		if m.readOnly {
+			return m, tea.ClearScreen
+		}
+		i, j := m.menu.GetCursor()
+		c := m.commands[i].CmdDescriptors[j]
+		t := mir_apiv1.DeviceTarget{
+			Ids: m.commands[i].DevicesId,
+		}
+		devCmds := mir_apiv1.SendCommandRequest{
+			Name:            c.Name,
+			Payload:         json.RawMessage(msg.Content),
+			PayloadEncoding: mir_apiv1.Encoding_ENCODING_JSON,
+			Targets:         &t,
+		}
+		return m, tea.Sequence(tea.ClearScreen, tea.Batch(
+			msgs.RouteChangeWithDataCmd(menuOption_device_command_response, &devCmds),
+		))
 	case tea.KeyMsg:
 		m.help, cmd = m.help.Update(msg)
-		if msg.String() == "g" {
-			// i, j := m.menu.GetCursor()
-			tlmQuery := "" // m.commands[i].TlmDescriptors[j].ExploreQuery
-			if tlmQuery != "" {
-				if err := grafana.OpenBrowser(grafana.CreateExploreLink(store.MirCtx.Grafana, tlmQuery)); err != nil {
-					return m, msgs.ErrCmd(fmt.Errorf("failed to open grafana link: %w", err), 2*time.Second)
+		if msg.String() == "q" || msg.String() == "r" {
+			i, j := m.menu.GetCursor()
+			cmdDesc := m.commands[i].CmdDescriptors[j]
+			query, err := prettyPrintJSON(cmdDesc.Template)
+			if err != nil {
+				query = err.Error()
+			}
+			if query != "" {
+				headers := []string{}
+				if msg.String() == "q" {
+					m.readOnly = true
+					headers = []string{
+						"READ-ONLY MODE: Command will not be sent",
+						cmdDesc.Name + "{" + mapToSortedString(cmdDesc.Labels, ", ") + "}",
+					}
+				} else {
+					headers = []string{
+						"SEND MODE: Command will be sent",
+						cmdDesc.Name + "{" + mapToSortedString(cmdDesc.Labels, ", ") + "}",
+					}
+					m.readOnly = false
 				}
-			} else {
-				return m, msgs.ErrCmd(fmt.Errorf("no grafana query available for this telemetry"), 2*time.Second)
+				return m, msgs.OpenEditorCmd(msgs.FileTypeJSON, []byte(query), headers)
 			}
-		} else if msg.String() == "q" {
-			// i, j := m.menu.GetCursor()
-			tlmQuery := "" // km.telemetry[i].TlmDescriptors[j].ExploreQuery
-			if tlmQuery != "" {
-				return m, msgs.OpenEditorCmd(msgs.FileTypeYAML, []byte(tlmQuery), []string{})
-			}
+		} else if msg.String() == "l" {
+			return m, msgs.RouteResume(menuOption_device_command_response)
 		} else {
 			m.menu, cmd = m.menu.Update(msg)
 		}
@@ -149,18 +195,6 @@ func (m *Model) View() string {
 	v.Reset()
 	v.WriteString("\n")
 
-	// q := ""
-	// i, j := m.menu.GetCursor()
-	// if len(m.telemetry) > i && len(m.telemetry[i].TlmDescriptors) > j {
-	// TODO in a future, the side panel will be a tlm chart
-	// q = m.telemetry[i].TlmDescriptors[j].ExploreQuery
-	// q = "{" + mapToSortedString(m.telemetry[i].TlmDescriptors[j].Labels) + "}\n"
-	// q += lipgloss.NewStyle().Bold(true).Render("Fields")
-	// q += "\n• " + strings.Join(m.telemetry[i].TlmDescriptors[j].Fields, "\n• ")
-	// q = styles.SidePanel.Render(q)
-	// }
-	// v.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, m.menu.View(), "          ", q))
-
 	v.WriteString(m.menu.View())
 	v.WriteString(m.help.View())
 	return v.String()
@@ -169,31 +203,35 @@ func (m *Model) View() string {
 type keyMap map[string]key.Binding
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k["space"], k["grafana"], k["query"]}
+	return []key.Binding{k["space"], k["send"], k["show"], k["last"]}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k["space"], k["grafana"], k["query"]},
+		{k["space"], k["send"], k["show"], k["last"]},
 	}
 }
 
 var keys = keyMap{
 	"space": key.NewBinding(
 		key.WithKeys(" "),
-		key.WithHelp("space", "fields"),
+		key.WithHelp("space", "labels"),
 	),
-	"grafana": key.NewBinding(
-		key.WithKeys("g"),
-		key.WithHelp("g", "grafana"),
-	),
-	"query": key.NewBinding(
+	"show": key.NewBinding(
 		key.WithKeys("q"),
-		key.WithHelp("q", "query"),
+		key.WithHelp("q", "show template"),
+	),
+	"send": key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "send command"),
+	),
+	"last": key.NewBinding(
+		key.WithKeys("l"),
+		key.WithHelp("l", "show last response"),
 	),
 }
 
-func mapToSortedString(m map[string]string) string {
+func mapToSortedString(m map[string]string, separator string) string {
 	if len(m) == 0 {
 		return ""
 	}
@@ -209,11 +247,25 @@ func mapToSortedString(m map[string]string) string {
 	var sb strings.Builder
 	for i, k := range keys {
 		if i > 0 {
-			sb.WriteString(", ")
+			sb.WriteString(separator)
 		}
 		sb.WriteString(k)
 		sb.WriteString("=")
 		sb.WriteString(m[k])
 	}
 	return sb.String()
+}
+
+func prettyPrintJSON(jsonStr string) (string, error) {
+	var obj any
+	if err := json.Unmarshal([]byte(jsonStr), &obj); err != nil {
+		return "", err
+	}
+
+	prettyJSON, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(prettyJSON), nil
 }

--- a/internal/ui/tui/pages/device/cmd/response/resp.go
+++ b/internal/ui/tui/pages/device/cmd/response/resp.go
@@ -1,0 +1,259 @@
+package device_command_response
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	mir_help "github.com/maxthom/mir/internal/ui/tui/components/help"
+	"github.com/maxthom/mir/internal/ui/tui/components/menu"
+	"github.com/maxthom/mir/internal/ui/tui/msgs"
+	"github.com/maxthom/mir/internal/ui/tui/store"
+	mir_apiv1 "github.com/maxthom/mir/pkgs/api/gen/proto/mir_api/v1"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	l zerolog.Logger
+	v strings.Builder
+)
+
+const ()
+
+type Model struct {
+	ctx     context.Context
+	help    mir_help.Model
+	cmdReq  *mir_apiv1.SendCommandRequest
+	cmdResp map[string]*mir_apiv1.SendCommandResponse_CommandResponse
+	vp      viewport.Model
+	list    menu.Model
+}
+
+type InputData struct {
+}
+
+func NewModel(ctx context.Context) *Model {
+	l = log.With().Str("page", "device_cmd_resp").Logger()
+
+	vp := viewport.New(store.ScreenWidth, store.ScreenHeight)
+	vp.Style = lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		PaddingRight(2)
+
+	return &Model{
+		ctx:  ctx,
+		help: mir_help.New(keys, []string{}, "mir command responses"),
+		vp:   vp,
+	}
+}
+
+func (m *Model) InitWithData(d any) tea.Cmd {
+	m.vp.Height = store.ScreenHeight - 5
+	m.vp.Width = 75 //store.ScreenWidth - 5
+	req, ok := d.(*mir_apiv1.SendCommandRequest)
+	if !ok {
+		return tea.Batch(
+			msgs.ErrCmd(fmt.Errorf("no command specified"), 2*time.Second),
+			msgs.RouteResume("/devices/commands"),
+		)
+	}
+	m.cmdReq = req
+
+	return tea.Batch(
+		msgs.ReqMsgCmd("Command '"+req.Name+"' sent to "+strconv.Itoa(len(req.Targets.Ids))+" devices", msgs.DefaultTimeout),
+		msgs.SendMirDeviceCommands(store.Bus, req),
+	)
+}
+
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		msgs.ErrCmd(fmt.Errorf("no command specified"), 2*time.Second),
+		msgs.RouteResume("/devices/commands"),
+	)
+}
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmdVp tea.Cmd
+	var cmdKey tea.Cmd
+	var cmdList tea.Cmd
+	var cmdRes tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.vp.Width = msg.Width - 4
+		m.vp.Height = msg.Height - 8
+	case msgs.DeviceCommandSentMsg:
+		m.cmdResp = msg.CommandsResponse
+		m.list = menu.New(m.renderCmdResp(m.cmdResp))
+		cmdRes = msgs.ResMsgCmd(strconv.Itoa(len(msg.CommandsResponse))+" command responses received", 5*time.Second)
+	case tea.KeyMsg:
+		m.help, cmdKey = m.help.Update(msg)
+		m.list, cmdList = m.list.Update(msg)
+		if cmdList != nil {
+			c := cmdList()
+			mv, ok := c.(menu.CursorMovedMsg)
+			if ok {
+				lineCount := len(strings.Split(m.list.GetChoice().Description, "\n"))
+				if mv.Position == 0 {
+					m.vp.GotoTop()
+				} else if len(m.cmdResp)-1 == mv.Position {
+					m.vp.GotoBottom()
+				} else {
+					m.vp.ScrollDown(mv.Direction * lineCount)
+				}
+			}
+		}
+		if msg.String() == "r" {
+			return m, m.InitWithData(m.cmdReq)
+		} else if msg.String() == "e" {
+			errorIds := []string{}
+			for _, resp := range m.cmdResp {
+				if resp.Status == mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_ERROR {
+					errorIds = append(errorIds, resp.DeviceId)
+				}
+			}
+			if len(errorIds) > 0 {
+				m.cmdReq.Targets.Ids = errorIds
+				return m, m.InitWithData(m.cmdReq)
+			} else {
+				return m, msgs.ResMsgCmd("No commands in error", 5*time.Second)
+			}
+		}
+	}
+
+	m.vp, cmdVp = m.vp.Update(msg)
+	return m, tea.Batch(cmdVp, cmdRes, cmdKey, cmdList)
+}
+
+func (m *Model) View() string {
+	v.Reset()
+	m.vp.SetContent(m.list.View())
+	v.WriteString(m.vp.View())
+	v.WriteString(m.help.View())
+	return v.String()
+}
+
+func (m *Model) renderCmdResp(resps map[string]*mir_apiv1.SendCommandResponse_CommandResponse) []menu.Option {
+	i := 1
+	choices := []menu.Option{}
+	for k, v := range resps {
+		var sb strings.Builder
+		if v.Error != "" {
+			errorText := v.Error
+			if len(errorText) > 50 {
+				lines := []string{}
+				start := 0
+				for start < len(errorText) {
+					end := start + 50
+					if end > len(errorText) {
+						end = len(errorText)
+					} else {
+						// Find the next space after position 30
+						spaceIdx := strings.IndexByte(errorText[end:], ' ')
+						if spaceIdx != -1 {
+							end += spaceIdx
+						}
+					}
+					lines = append(lines, errorText[start:end])
+					start = end
+					// Skip the space if we broke at one
+					if start < len(errorText) && errorText[start] == ' ' {
+						start++
+					}
+				}
+				sb.WriteString(strings.Join(lines, "\n    "))
+			} else {
+				sb.WriteString(errorText + "\n")
+			}
+		} else if len(v.Payload) > 0 {
+			sb.WriteString(v.Name)
+			sb.WriteString("\n")
+
+			p, err := prettyPrintJSON(string(v.Payload))
+			if err != nil {
+				sb.WriteString(errors.Wrap(err, "    error unmarshaling JSON in terminal").Error())
+			} else {
+				sb.WriteString("    " + p)
+			}
+		}
+		sb.WriteString("\n")
+
+		lbl := lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%d. %s", i, k))
+		st := ""
+		switch v.Status {
+		case mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_SUCCESS:
+			st = lipgloss.NewStyle().Foreground(lipgloss.Color("34")).Render("SUCCESS")
+		case mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_ERROR:
+			st = lipgloss.NewStyle().Foreground(lipgloss.Color("160")).Render("ERROR")
+		case mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_PENDING:
+			st = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("PENDING")
+		case mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_VALIDATED:
+			st = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("VALIDATED")
+		case mir_apiv1.CommandResponseStatus_COMMAND_RESPONSE_STATUS_UNSPECIFIED:
+			st = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("UNSPECIFIED")
+		}
+
+		choices = append(choices, menu.Option{
+			Value:       k,
+			Label:       lbl + " " + st,
+			Description: sb.String(),
+		})
+		i++
+	}
+	return choices
+}
+
+func prettyPrintJSON(jsonStr string) (string, error) {
+	var obj any
+	if err := json.Unmarshal([]byte(jsonStr), &obj); err != nil {
+		return "", err
+	}
+
+	prettyJSON, err := json.MarshalIndent(obj, "    ", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(prettyJSON), nil
+}
+
+type keyMap map[string]key.Binding
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k["again"], k["again_error"]}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k["again"], k["again_error"]},
+	}
+}
+
+var keys = keyMap{
+	"again": key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "resend command"),
+	),
+	"again_error": key.NewBinding(
+		key.WithKeys("e"),
+		key.WithHelp("e", "resend command in error"),
+	),
+}

--- a/internal/ui/tui/pages/device/create/create.go
+++ b/internal/ui/tui/pages/device/create/create.go
@@ -138,6 +138,14 @@ func (m *Model) Init() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd = make([]tea.Cmd, len(m.inputs))
 	switch msg := msg.(type) {
@@ -169,7 +177,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Disabled: &dis,
 					})
 				req.Meta.Annotations["mir/device/description"] = m.inputs[description].GetValue()
-				return m, tea.Batch(msgs.ReqMsgCmd("creating device..."), msgs.CreateMirDevice(store.Bus, req))
+				return m, tea.Batch(msgs.ReqMsgCmd("creating device...", msgs.DefaultTimeout), msgs.CreateMirDevice(store.Bus, req))
+
 			}
 		} else if msg.Label == "Create with random uuid" {
 			t, err := uuid.NewRandom()
@@ -187,7 +196,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			s = fmt.Sprintf("%d devices created", len(msg.Devices))
 		}
-		return m, tea.Batch(msgs.ResMsgCmd(s))
+		return m, tea.Batch(msgs.ResMsgCmd(s, msgs.DefaultTimeout))
 
 	case tea.KeyMsg:
 		switch msg.Type {

--- a/internal/ui/tui/pages/device/edit/edit.go
+++ b/internal/ui/tui/pages/device/edit/edit.go
@@ -64,6 +64,14 @@ func (m *Model) Init() tea.Cmd {
 	return msgs.OpenEditorCmd(msgs.FileTypeYAML, rj, headerComments)
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
@@ -72,7 +80,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.Devices) > 0 {
 			rsp = fmt.Sprintf("device '%s' edited successfully", msg.Devices[0].Spec.DeviceId)
 		}
-		return m, tea.Batch(msgs.ResMsgCmd(rsp), msgs.RouteChangeWithDataCmd("/devices", device_list.InputData{SilentFetch: true}))
+		return m, tea.Batch(msgs.ResMsgCmd(rsp, msgs.DefaultTimeout), msgs.RouteChangeWithDataCmd("/devices", device_list.InputData{SilentFetch: true}))
 	case msgs.EditorFinishedMsg:
 		var cmds []tea.Cmd
 		if msg.Err != nil {

--- a/internal/ui/tui/pages/device/list/list.go
+++ b/internal/ui/tui/pages/device/list/list.go
@@ -29,6 +29,7 @@ var (
 	menuOption_device_edit      string = "/devices/edit"
 	menuOption_device_schema    string = "/devices/schema"
 	menuOption_device_telemetry string = "/devices/telemetry"
+	menuOption_device_commands  string = "/devices/commands"
 	v                           strings.Builder
 )
 
@@ -261,7 +262,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, msgs.ErrCmd(fmt.Errorf("no device selected"), 2*time.Second)
 				}
 				return m, msgs.RouteChangeWithDataCmd(menuOption_device_telemetry, devices)
-
+			} else if msg.String() == "r" {
+				devices, ok := m.getSelectedDevices()
+				if !ok {
+					return m, msgs.ErrCmd(fmt.Errorf("no device selected"), 2*time.Second)
+				}
+				return m, msgs.RouteChangeWithDataCmd(menuOption_device_commands, devices)
 			} else {
 				m.table, cmd = m.table.Update(msg)
 			}

--- a/internal/ui/tui/pages/device/list/list.go
+++ b/internal/ui/tui/pages/device/list/list.go
@@ -131,7 +131,15 @@ func (m *Model) InitWithData(d any) tea.Cmd {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(m.timer.Init(), msgs.ReqMsgCmd("fetching devices..."), msgs.ListMirDevices(store.Bus))
+	return tea.Batch(m.timer.Init(), msgs.ReqMsgCmd("fetching devices...", 2*time.Second), msgs.ListMirDevices(store.Bus))
+}
+
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -155,14 +163,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.table.SetRows(rows)
 		if !msg.NoToast {
-			return m, msgs.ResMsgCmd(fmt.Sprintf("%d devices fetched", len(msg.Devices)))
+			return m, msgs.ResMsgCmd(fmt.Sprintf("%d devices fetched", len(msg.Devices)), msgs.DefaultTimeout)
 		}
 	case msgs.DeviceDeleteMsg:
 		rsp := "device deleted successfully"
 		if len(msg.Devices) > 0 {
 			rsp = fmt.Sprintf("device '%s' deleted", msg.Devices[0].Spec.DeviceId)
 		}
-		return m, tea.Batch(msgs.ListMirDevicesSilently(store.Bus), msgs.ResMsgCmd(rsp))
+		return m, tea.Batch(msgs.ListMirDevicesSilently(store.Bus), msgs.ResMsgCmd(rsp, msgs.DefaultTimeout))
 	case timer.TickMsg:
 		var cmd tea.Cmd
 		m.timer, cmd = m.timer.Update(msg)
@@ -213,7 +221,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, msgs.ErrCmd(fmt.Errorf("no device selected"), 2*time.Second)
 				}
 				return m, tea.Batch(
-					msgs.ReqMsgCmd("deleting device "+device.Spec.DeviceId+"..."),
+					msgs.ReqMsgCmd("deleting device "+device.Spec.DeviceId+"...", msgs.DefaultTimeout),
 					msgs.DeleteMirDevice(store.Bus, mir_v1.DeviceTarget{
 						Ids: []string{device.Spec.DeviceId},
 					}))

--- a/internal/ui/tui/pages/device/schema/schema.go
+++ b/internal/ui/tui/pages/device/schema/schema.go
@@ -74,6 +74,14 @@ func (m *Model) Init() tea.Cmd {
 	return msgs.OpenEditorCmd(msgs.FileTypeYAML, rj, headerComments)
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {

--- a/internal/ui/tui/pages/device/tlm/tlm.go
+++ b/internal/ui/tui/pages/device/tlm/tlm.go
@@ -77,8 +77,16 @@ func (m *Model) Init() tea.Cmd {
 	)
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
+	var tlm tea.Cmd
 	switch msg := msg.(type) {
 	case msgs.DeviceTelemetryListedMsg:
 		l.Debug().Int("count", len(msg.Telemetry)).Msg("received device telemetry list")
@@ -88,6 +96,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			gc := group_menu.GroupChoice{
 				Choices: []group_menu.Option{},
 			}
+
+			if len(tlm.DevicesNamens) > 3 {
+				gc.Label = strings.Join(tlm.DevicesNamens[0:3], ", ") + " & " + strconv.Itoa(len(tlm.DevicesNamens)-3) + " more"
+			} else if len(tlm.DevicesNamens) == 0 {
+				if len(tlm.DevicesId) > 3 {
+					gc.Label = strings.Join(tlm.DevicesId[0:3], ", ") + " & " + strconv.Itoa(len(tlm.DevicesId)-3) + " more"
+				} else {
+					gc.Label = strings.Join(tlm.DevicesId, ", ")
+				}
+			} else {
+				gc.Label = strings.Join(tlm.DevicesNamens, ", ")
+			}
+
 			if len(tlm.DevicesNamens) > 3 {
 				gc.Label = strings.Join(tlm.DevicesNamens[0:3], ", ") + " & " + strconv.Itoa(len(tlm.DevicesNamens)-3) + " more"
 			} else {
@@ -116,11 +137,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			groupchoice = append(groupchoice, gc)
 		}
 		m.menu = group_menu.New(groupchoice)
-		return m, msgs.ResMsgCmd(fmt.Sprintf("%d telemetry fetched", len(msg.Telemetry)))
+		return m, msgs.ResMsgCmd(fmt.Sprintf("%d telemetry fetched", len(msg.Telemetry)), msgs.DefaultTimeout)
 	case msgs.EditorFinishedMsg:
 		return m, nil
 	case tea.KeyMsg:
-		m.help, cmd = m.help.Update(msg)
+		m.help, tlm = m.help.Update(msg)
 		if msg.String() == "g" {
 			i, j := m.menu.GetCursor()
 			tlmQuery := m.telemetry[i].TlmDescriptors[j].ExploreQuery
@@ -138,9 +159,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, msgs.OpenEditorCmd(msgs.FileTypeYAML, []byte(tlmQuery), []string{})
 			}
 		} else {
-			m.menu, cmd = m.menu.Update(msg)
+			m.menu, tlm = m.menu.Update(msg)
 		}
-		return m, cmd
+		return m, tlm
 	}
 
 	return m, nil

--- a/internal/ui/tui/pages/mainmenu/main_menu.go
+++ b/internal/ui/tui/pages/mainmenu/main_menu.go
@@ -59,6 +59,14 @@ func (m Model) Init() tea.Cmd {
 	return nil
 }
 
+func (m Model) Resume() tea.Cmd {
+	return nil
+}
+
+func (m Model) ResumeWithData(d any) tea.Cmd {
+	return nil
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case menu.OptionSelectedMsg:

--- a/internal/ui/tui/router.go
+++ b/internal/ui/tui/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maxthom/mir/internal/ui/tui/components/menu"
 	"github.com/maxthom/mir/internal/ui/tui/msgs"
 	device_commands "github.com/maxthom/mir/internal/ui/tui/pages/device/cmd"
+	device_command_response "github.com/maxthom/mir/internal/ui/tui/pages/device/cmd/response"
 	device_create "github.com/maxthom/mir/internal/ui/tui/pages/device/create"
 	device_edit "github.com/maxthom/mir/internal/ui/tui/pages/device/edit"
 	device_list "github.com/maxthom/mir/internal/ui/tui/pages/device/list"
@@ -30,6 +31,8 @@ var v strings.Builder
 
 type MirTeaModel interface {
 	InitWithData(d any) tea.Cmd
+	ResumeWithData(d any) tea.Cmd
+	Resume() tea.Cmd
 	tea.Model
 }
 
@@ -46,15 +49,16 @@ func NewModel(ctx context.Context, log zerolog.Logger, m *mir.Mir, cfg ui.Config
 	log = log.With().Str("page", "router").Logger()
 	s := labelspinner.New(" 🛰️ ", styles.Mir.Render("Mir"), spinner.Dot)
 	routes := map[string]MirTeaModel{
-		"/":                  mainmenu.NewModel(),
-		"/devices":           device_list.NewModel(ctx),
-		"/devices/create":    device_create.NewModel(ctx),
-		"/devices/edit":      device_edit.NewModel(ctx),
-		"/devices/schema":    device_schema.NewModel(ctx),
-		"/devices/telemetry": device_telemetry.NewModel(ctx),
-		"/devices/commands":  device_commands.NewModel(ctx),
-		"/twins":             nil,
-		"/telemetry":         nil,
+		"/":                           mainmenu.NewModel(),
+		"/devices":                    device_list.NewModel(ctx),
+		"/devices/create":             device_create.NewModel(ctx),
+		"/devices/edit":               device_edit.NewModel(ctx),
+		"/devices/schema":             device_schema.NewModel(ctx),
+		"/devices/telemetry":          device_telemetry.NewModel(ctx),
+		"/devices/commands":           device_commands.NewModel(ctx),
+		"/devices/commands/responses": device_command_response.NewModel(ctx),
+		"/twins":                      nil,
+		"/telemetry":                  nil,
 	}
 	return &Model{
 		ctx:          ctx,
@@ -67,7 +71,7 @@ func NewModel(ctx context.Context, log zerolog.Logger, m *mir.Mir, cfg ui.Config
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(msgs.ReqMsgCmd("connecting to Mir ...standby"), m.connectToMir())
+	return tea.Sequence(tea.ClearScreen, tea.Batch(msgs.ReqMsgCmd("connecting to Mir ...standby", msgs.DefaultTimeout), m.connectToMir()))
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -76,10 +80,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		store.ScreenWidth = msg.Width
 		store.ScreenHeight = msg.Height
 	case msgs.ReqMsg:
-		m.lblSpinner.UpdateLabel(styles.Info.Render(string(msg)))
-		return m, m.lblSpinner.Start()
+		var cmd tea.Cmd
+		if msg.Timeout != 0 {
+			cmd = m.lblSpinner.UpdateLabelWithTimeout(styles.Info.Render(msg.Msg), msg.Timeout)
+		} else {
+			m.lblSpinner.UpdateLabel(styles.Info.Render(msg.Msg))
+		}
+		return m, tea.Batch(m.lblSpinner.Start(), cmd)
 	case msgs.ResMsg:
-		cmd := m.lblSpinner.UpdateLabelWithTimeout(styles.Info.Render(msg), 2*time.Second)
+		var cmd tea.Cmd
+		if msg.Timeout != 0 {
+			cmd = m.lblSpinner.UpdateLabelWithTimeout(styles.Info.Render(msg.Msg), msg.Timeout)
+		} else {
+			m.lblSpinner.UpdateLabel(styles.Info.Render(msg.Msg))
+		}
 		return m, tea.Batch(m.lblSpinner.Stop(), cmd)
 	case msgs.ErrMsg:
 		if msg.Timeout != 0 {
@@ -93,9 +107,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.routes[m.currentRoute] == nil {
 			m.currentRoute = "/"
 			return m, m.lblSpinner.UpdateLabelWithTimeout(styles.Error.Render("not implemented yet"), 2*time.Second)
-		} else {
-			// TODO add route param to say if init or not
+		} else if msg.Data != nil {
 			return m, m.routes[m.currentRoute].InitWithData(msg.Data)
+		} else {
+			return m, m.routes[m.currentRoute].Init()
+		}
+	case msgs.RouteResumeMsg:
+		m.currentRoute = msg.Route
+		if m.routes[m.currentRoute] == nil {
+			m.currentRoute = "/"
+			return m, m.lblSpinner.UpdateLabelWithTimeout(styles.Error.Render("not implemented yet"), 2*time.Second)
+		} else if msg.Data == nil {
+			return m, m.routes[m.currentRoute].ResumeWithData(msg.Data)
+		} else {
+			return m, m.routes[m.currentRoute].Resume()
 		}
 	case tea.KeyMsg:
 		var cmd tea.Cmd
@@ -103,7 +128,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case msg.Type == tea.KeyCtrlC:
 			return m, tea.Quit
 		case msg.Type == tea.KeyEscape:
-			return m, msgs.RouteChangeCmd(removeLastSegment(m.currentRoute))
+			return m, msgs.RouteResume(removeLastSegment(m.currentRoute))
 		default:
 			rm, cmd := m.routes[m.currentRoute].Update(msg)
 			m.routes[m.currentRoute] = rm.(MirTeaModel)
@@ -144,6 +169,6 @@ func removeLastSegment(path string) string {
 func (m *Model) connectToMir() tea.Cmd {
 	return func() tea.Msg {
 		store.Bus = m.m
-		return msgs.ResMsg("connected to Mir")
+		return msgs.ResMsgCmd("connected to Mir", msgs.DefaultTimeout)
 	}
 }

--- a/internal/ui/tui/router.go
+++ b/internal/ui/tui/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/maxthom/mir/internal/ui/tui/components/labelspinner"
 	"github.com/maxthom/mir/internal/ui/tui/components/menu"
 	"github.com/maxthom/mir/internal/ui/tui/msgs"
+	device_commands "github.com/maxthom/mir/internal/ui/tui/pages/device/cmd"
 	device_create "github.com/maxthom/mir/internal/ui/tui/pages/device/create"
 	device_edit "github.com/maxthom/mir/internal/ui/tui/pages/device/edit"
 	device_list "github.com/maxthom/mir/internal/ui/tui/pages/device/list"
@@ -51,6 +52,7 @@ func NewModel(ctx context.Context, log zerolog.Logger, m *mir.Mir, cfg ui.Config
 		"/devices/edit":      device_edit.NewModel(ctx),
 		"/devices/schema":    device_schema.NewModel(ctx),
 		"/devices/telemetry": device_telemetry.NewModel(ctx),
+		"/devices/commands":  device_commands.NewModel(ctx),
 		"/twins":             nil,
 		"/telemetry":         nil,
 	}

--- a/pkgs/api/gen/proto/mir_api/v1/cfg.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/cfg.pb.go
@@ -396,7 +396,7 @@ func (x *SendListConfigResponse) GetResponse() isSendListConfigResponse_Response
 	return nil
 }
 
-func (x *SendListConfigResponse) GetOk() *DevicesConfigs {
+func (x *SendListConfigResponse) GetOk() *ConfigsResponse {
 	if x != nil {
 		if x, ok := x.Response.(*SendListConfigResponse_Ok); ok {
 			return x.Ok
@@ -419,7 +419,7 @@ type isSendListConfigResponse_Response interface {
 }
 
 type SendListConfigResponse_Ok struct {
-	Ok *DevicesConfigs `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // all configs per devices
+	Ok *ConfigsResponse `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // all configs per devices
 }
 
 type SendListConfigResponse_Error struct {
@@ -431,16 +431,63 @@ func (*SendListConfigResponse_Ok) isSendListConfigResponse_Response() {}
 func (*SendListConfigResponse_Error) isSendListConfigResponse_Response() {}
 
 // Map of device id and its list of configs
-type DevicesConfigs struct {
+type ConfigsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	DeviceConfigs map[string]*Configs    `protobuf:"bytes,1,rep,name=device_configs,json=deviceConfigs,proto3" json:"device_configs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // all config per devices
+	DeviceConfigs []*DevicesConfigs      `protobuf:"bytes,1,rep,name=device_configs,json=deviceConfigs,proto3" json:"device_configs,omitempty"` // all config per devices
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *ConfigsResponse) Reset() {
+	*x = ConfigsResponse{}
+	mi := &file_mir_api_v1_cfg_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigsResponse) ProtoMessage() {}
+
+func (x *ConfigsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mir_api_v1_cfg_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigsResponse.ProtoReflect.Descriptor instead.
+func (*ConfigsResponse) Descriptor() ([]byte, []int) {
+	return file_mir_api_v1_cfg_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ConfigsResponse) GetDeviceConfigs() []*DevicesConfigs {
+	if x != nil {
+		return x.DeviceConfigs
+	}
+	return nil
+}
+
+// List of config
+type DevicesConfigs struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	DevicesNamens  []string               `protobuf:"bytes,1,rep,name=devices_namens,json=devicesNamens,proto3" json:"devices_namens,omitempty"`    // List of devices that have this telemetry
+	CfgDescriptors []*ConfigDescriptor    `protobuf:"bytes,2,rep,name=cfg_descriptors,json=cfgDescriptors,proto3" json:"cfg_descriptors,omitempty"` // Array of config descriptor
+	Error          string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`                                         // error if something went wrong
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
 func (x *DevicesConfigs) Reset() {
 	*x = DevicesConfigs{}
-	mi := &file_mir_api_v1_cfg_proto_msgTypes[4]
+	mi := &file_mir_api_v1_cfg_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -452,7 +499,7 @@ func (x *DevicesConfigs) String() string {
 func (*DevicesConfigs) ProtoMessage() {}
 
 func (x *DevicesConfigs) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_cfg_proto_msgTypes[4]
+	mi := &file_mir_api_v1_cfg_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -465,63 +512,24 @@ func (x *DevicesConfigs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DevicesConfigs.ProtoReflect.Descriptor instead.
 func (*DevicesConfigs) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_cfg_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *DevicesConfigs) GetDeviceConfigs() map[string]*Configs {
-	if x != nil {
-		return x.DeviceConfigs
-	}
-	return nil
-}
-
-// List of config
-type Configs struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Configs       []*ConfigDescriptor    `protobuf:"bytes,1,rep,name=configs,proto3" json:"configs,omitempty"` // Array of config descriptor
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`     // error if something went wrong
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Configs) Reset() {
-	*x = Configs{}
-	mi := &file_mir_api_v1_cfg_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Configs) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Configs) ProtoMessage() {}
-
-func (x *Configs) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_cfg_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Configs.ProtoReflect.Descriptor instead.
-func (*Configs) Descriptor() ([]byte, []int) {
 	return file_mir_api_v1_cfg_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *Configs) GetConfigs() []*ConfigDescriptor {
+func (x *DevicesConfigs) GetDevicesNamens() []string {
 	if x != nil {
-		return x.Configs
+		return x.DevicesNamens
 	}
 	return nil
 }
 
-func (x *Configs) GetError() string {
+func (x *DevicesConfigs) GetCfgDescriptors() []*ConfigDescriptor {
+	if x != nil {
+		return x.CfgDescriptors
+	}
+	return nil
+}
+
+func (x *DevicesConfigs) GetError() string {
 	if x != nil {
 		return x.Error
 	}
@@ -776,20 +784,18 @@ const file_mir_api_v1_cfg_proto_rawDesc = "" +
 	"\x0erefresh_schema\x18\x03 \x01(\bR\rrefreshSchema\x1a?\n" +
 	"\x11FilterLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"j\n" +
-	"\x16SendListConfigResponse\x12,\n" +
-	"\x02ok\x18\x01 \x01(\v2\x1a.mir_api.v1.DevicesConfigsH\x00R\x02ok\x12\x16\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"k\n" +
+	"\x16SendListConfigResponse\x12-\n" +
+	"\x02ok\x18\x01 \x01(\v2\x1b.mir_api.v1.ConfigsResponseH\x00R\x02ok\x12\x16\n" +
 	"\x05error\x18\x02 \x01(\tH\x00R\x05errorB\n" +
 	"\n" +
-	"\bresponse\"\xbd\x01\n" +
-	"\x0eDevicesConfigs\x12T\n" +
-	"\x0edevice_configs\x18\x01 \x03(\v2-.mir_api.v1.DevicesConfigs.DeviceConfigsEntryR\rdeviceConfigs\x1aU\n" +
-	"\x12DeviceConfigsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.mir_api.v1.ConfigsR\x05value:\x028\x01\"W\n" +
-	"\aConfigs\x126\n" +
-	"\aconfigs\x18\x01 \x03(\v2\x1c.mir_api.v1.ConfigDescriptorR\aconfigs\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\xed\x01\n" +
+	"\bresponse\"T\n" +
+	"\x0fConfigsResponse\x12A\n" +
+	"\x0edevice_configs\x18\x01 \x03(\v2\x1a.mir_api.v1.DevicesConfigsR\rdeviceConfigs\"\x94\x01\n" +
+	"\x0eDevicesConfigs\x12%\n" +
+	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12E\n" +
+	"\x0fcfg_descriptors\x18\x02 \x03(\v2\x1c.mir_api.v1.ConfigDescriptorR\x0ecfgDescriptors\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xed\x01\n" +
 	"\x10ConfigDescriptor\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12@\n" +
 	"\x06labels\x18\x02 \x03(\v2(.mir_api.v1.ConfigDescriptor.LabelsEntryR\x06labels\x12\x1a\n" +
@@ -822,45 +828,43 @@ func file_mir_api_v1_cfg_proto_rawDescGZIP() []byte {
 }
 
 var file_mir_api_v1_cfg_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_mir_api_v1_cfg_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_mir_api_v1_cfg_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_mir_api_v1_cfg_proto_goTypes = []any{
 	(ConfigResponseStatus)(0),                  // 0: mir_api.v1.ConfigResponseStatus
 	(*SendConfigRequest)(nil),                  // 1: mir_api.v1.SendConfigRequest
 	(*SendConfigResponse)(nil),                 // 2: mir_api.v1.SendConfigResponse
 	(*SendListConfigRequest)(nil),              // 3: mir_api.v1.SendListConfigRequest
 	(*SendListConfigResponse)(nil),             // 4: mir_api.v1.SendListConfigResponse
-	(*DevicesConfigs)(nil),                     // 5: mir_api.v1.DevicesConfigs
-	(*Configs)(nil),                            // 6: mir_api.v1.Configs
+	(*ConfigsResponse)(nil),                    // 5: mir_api.v1.ConfigsResponse
+	(*DevicesConfigs)(nil),                     // 6: mir_api.v1.DevicesConfigs
 	(*ConfigDescriptor)(nil),                   // 7: mir_api.v1.ConfigDescriptor
 	(*SendConfigResponse_ConfigResponses)(nil), // 8: mir_api.v1.SendConfigResponse.ConfigResponses
 	(*SendConfigResponse_ConfigResponse)(nil),  // 9: mir_api.v1.SendConfigResponse.ConfigResponse
 	nil,                  // 10: mir_api.v1.SendConfigResponse.ConfigResponses.DeviceResponsesEntry
 	nil,                  // 11: mir_api.v1.SendListConfigRequest.FilterLabelsEntry
-	nil,                  // 12: mir_api.v1.DevicesConfigs.DeviceConfigsEntry
-	nil,                  // 13: mir_api.v1.ConfigDescriptor.LabelsEntry
-	(*DeviceTarget)(nil), // 14: mir_api.v1.DeviceTarget
-	(Encoding)(0),        // 15: mir_api.v1.Encoding
+	nil,                  // 12: mir_api.v1.ConfigDescriptor.LabelsEntry
+	(*DeviceTarget)(nil), // 13: mir_api.v1.DeviceTarget
+	(Encoding)(0),        // 14: mir_api.v1.Encoding
 }
 var file_mir_api_v1_cfg_proto_depIdxs = []int32{
-	14, // 0: mir_api.v1.SendConfigRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	15, // 1: mir_api.v1.SendConfigRequest.payload_encoding:type_name -> mir_api.v1.Encoding
+	13, // 0: mir_api.v1.SendConfigRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	14, // 1: mir_api.v1.SendConfigRequest.payload_encoding:type_name -> mir_api.v1.Encoding
 	8,  // 2: mir_api.v1.SendConfigResponse.ok:type_name -> mir_api.v1.SendConfigResponse.ConfigResponses
-	14, // 3: mir_api.v1.SendListConfigRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	13, // 3: mir_api.v1.SendListConfigRequest.targets:type_name -> mir_api.v1.DeviceTarget
 	11, // 4: mir_api.v1.SendListConfigRequest.filter_labels:type_name -> mir_api.v1.SendListConfigRequest.FilterLabelsEntry
-	5,  // 5: mir_api.v1.SendListConfigResponse.ok:type_name -> mir_api.v1.DevicesConfigs
-	12, // 6: mir_api.v1.DevicesConfigs.device_configs:type_name -> mir_api.v1.DevicesConfigs.DeviceConfigsEntry
-	7,  // 7: mir_api.v1.Configs.configs:type_name -> mir_api.v1.ConfigDescriptor
-	13, // 8: mir_api.v1.ConfigDescriptor.labels:type_name -> mir_api.v1.ConfigDescriptor.LabelsEntry
+	5,  // 5: mir_api.v1.SendListConfigResponse.ok:type_name -> mir_api.v1.ConfigsResponse
+	6,  // 6: mir_api.v1.ConfigsResponse.device_configs:type_name -> mir_api.v1.DevicesConfigs
+	7,  // 7: mir_api.v1.DevicesConfigs.cfg_descriptors:type_name -> mir_api.v1.ConfigDescriptor
+	12, // 8: mir_api.v1.ConfigDescriptor.labels:type_name -> mir_api.v1.ConfigDescriptor.LabelsEntry
 	10, // 9: mir_api.v1.SendConfigResponse.ConfigResponses.device_responses:type_name -> mir_api.v1.SendConfigResponse.ConfigResponses.DeviceResponsesEntry
-	15, // 10: mir_api.v1.SendConfigResponse.ConfigResponses.encoding:type_name -> mir_api.v1.Encoding
+	14, // 10: mir_api.v1.SendConfigResponse.ConfigResponses.encoding:type_name -> mir_api.v1.Encoding
 	0,  // 11: mir_api.v1.SendConfigResponse.ConfigResponse.status:type_name -> mir_api.v1.ConfigResponseStatus
 	9,  // 12: mir_api.v1.SendConfigResponse.ConfigResponses.DeviceResponsesEntry.value:type_name -> mir_api.v1.SendConfigResponse.ConfigResponse
-	6,  // 13: mir_api.v1.DevicesConfigs.DeviceConfigsEntry.value:type_name -> mir_api.v1.Configs
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_mir_api_v1_cfg_proto_init() }
@@ -884,7 +888,7 @@ func file_mir_api_v1_cfg_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mir_api_v1_cfg_proto_rawDesc), len(file_mir_api_v1_cfg_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   13,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkgs/api/gen/proto/mir_api/v1/cfg.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/cfg.pb.go
@@ -479,8 +479,9 @@ func (x *ConfigsResponse) GetDeviceConfigs() []*DevicesConfigs {
 type DevicesConfigs struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	DevicesNamens  []string               `protobuf:"bytes,1,rep,name=devices_namens,json=devicesNamens,proto3" json:"devices_namens,omitempty"`    // List of devices that have this telemetry
-	CfgDescriptors []*ConfigDescriptor    `protobuf:"bytes,2,rep,name=cfg_descriptors,json=cfgDescriptors,proto3" json:"cfg_descriptors,omitempty"` // Array of config descriptor
-	Error          string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`                                         // error if something went wrong
+	DevicesId      []string               `protobuf:"bytes,2,rep,name=devices_id,json=devicesId,proto3" json:"devices_id,omitempty"`                // List of devices that have this telemetry
+	CfgDescriptors []*ConfigDescriptor    `protobuf:"bytes,3,rep,name=cfg_descriptors,json=cfgDescriptors,proto3" json:"cfg_descriptors,omitempty"` // Array of config descriptor
+	Error          string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`                                         // error if something went wrong
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -518,6 +519,13 @@ func (*DevicesConfigs) Descriptor() ([]byte, []int) {
 func (x *DevicesConfigs) GetDevicesNamens() []string {
 	if x != nil {
 		return x.DevicesNamens
+	}
+	return nil
+}
+
+func (x *DevicesConfigs) GetDevicesId() []string {
+	if x != nil {
+		return x.DevicesId
 	}
 	return nil
 }
@@ -791,11 +799,13 @@ const file_mir_api_v1_cfg_proto_rawDesc = "" +
 	"\n" +
 	"\bresponse\"T\n" +
 	"\x0fConfigsResponse\x12A\n" +
-	"\x0edevice_configs\x18\x01 \x03(\v2\x1a.mir_api.v1.DevicesConfigsR\rdeviceConfigs\"\x94\x01\n" +
+	"\x0edevice_configs\x18\x01 \x03(\v2\x1a.mir_api.v1.DevicesConfigsR\rdeviceConfigs\"\xb3\x01\n" +
 	"\x0eDevicesConfigs\x12%\n" +
-	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12E\n" +
-	"\x0fcfg_descriptors\x18\x02 \x03(\v2\x1c.mir_api.v1.ConfigDescriptorR\x0ecfgDescriptors\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"\xed\x01\n" +
+	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12\x1d\n" +
+	"\n" +
+	"devices_id\x18\x02 \x03(\tR\tdevicesId\x12E\n" +
+	"\x0fcfg_descriptors\x18\x03 \x03(\v2\x1c.mir_api.v1.ConfigDescriptorR\x0ecfgDescriptors\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\xed\x01\n" +
 	"\x10ConfigDescriptor\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12@\n" +
 	"\x06labels\x18\x02 \x03(\v2(.mir_api.v1.ConfigDescriptor.LabelsEntryR\x06labels\x12\x1a\n" +

--- a/pkgs/api/gen/proto/mir_api/v1/cmd.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/cmd.pb.go
@@ -476,8 +476,9 @@ func (x *CommandsResponse) GetDevicesCommands() []*DevicesCommands {
 type DevicesCommands struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	DevicesNamens  []string               `protobuf:"bytes,1,rep,name=devices_namens,json=devicesNamens,proto3" json:"devices_namens,omitempty"`    // List of devices that have this telemetry
-	CmdDescriptors []*CommandDescriptor   `protobuf:"bytes,2,rep,name=cmd_descriptors,json=cmdDescriptors,proto3" json:"cmd_descriptors,omitempty"` // Array of command descriptor
-	Error          string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`                                         // HTTP like error if something went wrong
+	DevicesId      []string               `protobuf:"bytes,2,rep,name=devices_id,json=devicesId,proto3" json:"devices_id,omitempty"`                // List of devices that have this telemetry
+	CmdDescriptors []*CommandDescriptor   `protobuf:"bytes,3,rep,name=cmd_descriptors,json=cmdDescriptors,proto3" json:"cmd_descriptors,omitempty"` // Array of command descriptor
+	Error          string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`                                         // HTTP like error if something went wrong
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -515,6 +516,13 @@ func (*DevicesCommands) Descriptor() ([]byte, []int) {
 func (x *DevicesCommands) GetDevicesNamens() []string {
 	if x != nil {
 		return x.DevicesNamens
+	}
+	return nil
+}
+
+func (x *DevicesCommands) GetDevicesId() []string {
+	if x != nil {
+		return x.DevicesId
 	}
 	return nil
 }
@@ -780,11 +788,13 @@ const file_mir_api_v1_cmd_proto_rawDesc = "" +
 	"\n" +
 	"\bresponse\"Z\n" +
 	"\x10CommandsResponse\x12F\n" +
-	"\x10devices_commands\x18\x01 \x03(\v2\x1b.mir_api.v1.DevicesCommandsR\x0fdevicesCommands\"\x96\x01\n" +
+	"\x10devices_commands\x18\x01 \x03(\v2\x1b.mir_api.v1.DevicesCommandsR\x0fdevicesCommands\"\xb5\x01\n" +
 	"\x0fDevicesCommands\x12%\n" +
-	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12F\n" +
-	"\x0fcmd_descriptors\x18\x02 \x03(\v2\x1d.mir_api.v1.CommandDescriptorR\x0ecmdDescriptors\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"\xd7\x01\n" +
+	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12\x1d\n" +
+	"\n" +
+	"devices_id\x18\x02 \x03(\tR\tdevicesId\x12F\n" +
+	"\x0fcmd_descriptors\x18\x03 \x03(\v2\x1d.mir_api.v1.CommandDescriptorR\x0ecmdDescriptors\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\xd7\x01\n" +
 	"\x11CommandDescriptor\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12A\n" +
 	"\x06labels\x18\x02 \x03(\v2).mir_api.v1.CommandDescriptor.LabelsEntryR\x06labels\x12\x1a\n" +

--- a/pkgs/api/gen/proto/mir_api/v1/cmd.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/cmd.pb.go
@@ -393,7 +393,7 @@ func (x *SendListCommandsResponse) GetResponse() isSendListCommandsResponse_Resp
 	return nil
 }
 
-func (x *SendListCommandsResponse) GetOk() *DevicesCommands {
+func (x *SendListCommandsResponse) GetOk() *CommandsResponse {
 	if x != nil {
 		if x, ok := x.Response.(*SendListCommandsResponse_Ok); ok {
 			return x.Ok
@@ -416,7 +416,7 @@ type isSendListCommandsResponse_Response interface {
 }
 
 type SendListCommandsResponse_Ok struct {
-	Ok *DevicesCommands `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // all commands per devices
+	Ok *CommandsResponse `protobuf:"bytes,1,opt,name=ok,proto3,oneof"` // all commands per devices
 }
 
 type SendListCommandsResponse_Error struct {
@@ -428,16 +428,63 @@ func (*SendListCommandsResponse_Ok) isSendListCommandsResponse_Response() {}
 func (*SendListCommandsResponse_Error) isSendListCommandsResponse_Response() {}
 
 // Map of device id and its list of commands
+type CommandsResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	DevicesCommands []*DevicesCommands     `protobuf:"bytes,1,rep,name=devices_commands,json=devicesCommands,proto3" json:"devices_commands,omitempty"` // all commands per devices
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *CommandsResponse) Reset() {
+	*x = CommandsResponse{}
+	mi := &file_mir_api_v1_cmd_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommandsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommandsResponse) ProtoMessage() {}
+
+func (x *CommandsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_mir_api_v1_cmd_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommandsResponse.ProtoReflect.Descriptor instead.
+func (*CommandsResponse) Descriptor() ([]byte, []int) {
+	return file_mir_api_v1_cmd_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CommandsResponse) GetDevicesCommands() []*DevicesCommands {
+	if x != nil {
+		return x.DevicesCommands
+	}
+	return nil
+}
+
+// List of commands
 type DevicesCommands struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
-	DeviceCommands map[string]*Commands   `protobuf:"bytes,1,rep,name=device_commands,json=deviceCommands,proto3" json:"device_commands,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // all commands per devices
+	DevicesNamens  []string               `protobuf:"bytes,1,rep,name=devices_namens,json=devicesNamens,proto3" json:"devices_namens,omitempty"`    // List of devices that have this telemetry
+	CmdDescriptors []*CommandDescriptor   `protobuf:"bytes,2,rep,name=cmd_descriptors,json=cmdDescriptors,proto3" json:"cmd_descriptors,omitempty"` // Array of command descriptor
+	Error          string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`                                         // HTTP like error if something went wrong
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *DevicesCommands) Reset() {
 	*x = DevicesCommands{}
-	mi := &file_mir_api_v1_cmd_proto_msgTypes[4]
+	mi := &file_mir_api_v1_cmd_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -449,7 +496,7 @@ func (x *DevicesCommands) String() string {
 func (*DevicesCommands) ProtoMessage() {}
 
 func (x *DevicesCommands) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_cmd_proto_msgTypes[4]
+	mi := &file_mir_api_v1_cmd_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -462,63 +509,24 @@ func (x *DevicesCommands) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DevicesCommands.ProtoReflect.Descriptor instead.
 func (*DevicesCommands) Descriptor() ([]byte, []int) {
-	return file_mir_api_v1_cmd_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *DevicesCommands) GetDeviceCommands() map[string]*Commands {
-	if x != nil {
-		return x.DeviceCommands
-	}
-	return nil
-}
-
-// List of commands
-type Commands struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Commands      []*CommandDescriptor   `protobuf:"bytes,1,rep,name=commands,proto3" json:"commands,omitempty"` // Array of command descriptor
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`       // HTTP like error if something went wrong
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Commands) Reset() {
-	*x = Commands{}
-	mi := &file_mir_api_v1_cmd_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Commands) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Commands) ProtoMessage() {}
-
-func (x *Commands) ProtoReflect() protoreflect.Message {
-	mi := &file_mir_api_v1_cmd_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Commands.ProtoReflect.Descriptor instead.
-func (*Commands) Descriptor() ([]byte, []int) {
 	return file_mir_api_v1_cmd_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *Commands) GetCommands() []*CommandDescriptor {
+func (x *DevicesCommands) GetDevicesNamens() []string {
 	if x != nil {
-		return x.Commands
+		return x.DevicesNamens
 	}
 	return nil
 }
 
-func (x *Commands) GetError() string {
+func (x *DevicesCommands) GetCmdDescriptors() []*CommandDescriptor {
+	if x != nil {
+		return x.CmdDescriptors
+	}
+	return nil
+}
+
+func (x *DevicesCommands) GetError() string {
 	if x != nil {
 		return x.Error
 	}
@@ -765,20 +773,18 @@ const file_mir_api_v1_cmd_proto_rawDesc = "" +
 	"\x0erefresh_schema\x18\x03 \x01(\bR\rrefreshSchema\x1a?\n" +
 	"\x11FilterLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"m\n" +
-	"\x18SendListCommandsResponse\x12-\n" +
-	"\x02ok\x18\x01 \x01(\v2\x1b.mir_api.v1.DevicesCommandsH\x00R\x02ok\x12\x16\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"n\n" +
+	"\x18SendListCommandsResponse\x12.\n" +
+	"\x02ok\x18\x01 \x01(\v2\x1c.mir_api.v1.CommandsResponseH\x00R\x02ok\x12\x16\n" +
 	"\x05error\x18\x02 \x01(\tH\x00R\x05errorB\n" +
 	"\n" +
-	"\bresponse\"\xc4\x01\n" +
-	"\x0fDevicesCommands\x12X\n" +
-	"\x0fdevice_commands\x18\x01 \x03(\v2/.mir_api.v1.DevicesCommands.DeviceCommandsEntryR\x0edeviceCommands\x1aW\n" +
-	"\x13DeviceCommandsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
-	"\x05value\x18\x02 \x01(\v2\x14.mir_api.v1.CommandsR\x05value:\x028\x01\"[\n" +
-	"\bCommands\x129\n" +
-	"\bcommands\x18\x01 \x03(\v2\x1d.mir_api.v1.CommandDescriptorR\bcommands\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\xd7\x01\n" +
+	"\bresponse\"Z\n" +
+	"\x10CommandsResponse\x12F\n" +
+	"\x10devices_commands\x18\x01 \x03(\v2\x1b.mir_api.v1.DevicesCommandsR\x0fdevicesCommands\"\x96\x01\n" +
+	"\x0fDevicesCommands\x12%\n" +
+	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12F\n" +
+	"\x0fcmd_descriptors\x18\x02 \x03(\v2\x1d.mir_api.v1.CommandDescriptorR\x0ecmdDescriptors\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xd7\x01\n" +
 	"\x11CommandDescriptor\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12A\n" +
 	"\x06labels\x18\x02 \x03(\v2).mir_api.v1.CommandDescriptor.LabelsEntryR\x06labels\x12\x1a\n" +
@@ -809,45 +815,43 @@ func file_mir_api_v1_cmd_proto_rawDescGZIP() []byte {
 }
 
 var file_mir_api_v1_cmd_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_mir_api_v1_cmd_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_mir_api_v1_cmd_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_mir_api_v1_cmd_proto_goTypes = []any{
 	(CommandResponseStatus)(0),                   // 0: mir_api.v1.CommandResponseStatus
 	(*SendCommandRequest)(nil),                   // 1: mir_api.v1.SendCommandRequest
 	(*SendCommandResponse)(nil),                  // 2: mir_api.v1.SendCommandResponse
 	(*SendListCommandsRequest)(nil),              // 3: mir_api.v1.SendListCommandsRequest
 	(*SendListCommandsResponse)(nil),             // 4: mir_api.v1.SendListCommandsResponse
-	(*DevicesCommands)(nil),                      // 5: mir_api.v1.DevicesCommands
-	(*Commands)(nil),                             // 6: mir_api.v1.Commands
+	(*CommandsResponse)(nil),                     // 5: mir_api.v1.CommandsResponse
+	(*DevicesCommands)(nil),                      // 6: mir_api.v1.DevicesCommands
 	(*CommandDescriptor)(nil),                    // 7: mir_api.v1.CommandDescriptor
 	(*SendCommandResponse_CommandResponses)(nil), // 8: mir_api.v1.SendCommandResponse.CommandResponses
 	(*SendCommandResponse_CommandResponse)(nil),  // 9: mir_api.v1.SendCommandResponse.CommandResponse
 	nil,                  // 10: mir_api.v1.SendCommandResponse.CommandResponses.DeviceResponsesEntry
 	nil,                  // 11: mir_api.v1.SendListCommandsRequest.FilterLabelsEntry
-	nil,                  // 12: mir_api.v1.DevicesCommands.DeviceCommandsEntry
-	nil,                  // 13: mir_api.v1.CommandDescriptor.LabelsEntry
-	(*DeviceTarget)(nil), // 14: mir_api.v1.DeviceTarget
-	(Encoding)(0),        // 15: mir_api.v1.Encoding
+	nil,                  // 12: mir_api.v1.CommandDescriptor.LabelsEntry
+	(*DeviceTarget)(nil), // 13: mir_api.v1.DeviceTarget
+	(Encoding)(0),        // 14: mir_api.v1.Encoding
 }
 var file_mir_api_v1_cmd_proto_depIdxs = []int32{
-	14, // 0: mir_api.v1.SendCommandRequest.targets:type_name -> mir_api.v1.DeviceTarget
-	15, // 1: mir_api.v1.SendCommandRequest.payload_encoding:type_name -> mir_api.v1.Encoding
+	13, // 0: mir_api.v1.SendCommandRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	14, // 1: mir_api.v1.SendCommandRequest.payload_encoding:type_name -> mir_api.v1.Encoding
 	8,  // 2: mir_api.v1.SendCommandResponse.ok:type_name -> mir_api.v1.SendCommandResponse.CommandResponses
-	14, // 3: mir_api.v1.SendListCommandsRequest.targets:type_name -> mir_api.v1.DeviceTarget
+	13, // 3: mir_api.v1.SendListCommandsRequest.targets:type_name -> mir_api.v1.DeviceTarget
 	11, // 4: mir_api.v1.SendListCommandsRequest.filter_labels:type_name -> mir_api.v1.SendListCommandsRequest.FilterLabelsEntry
-	5,  // 5: mir_api.v1.SendListCommandsResponse.ok:type_name -> mir_api.v1.DevicesCommands
-	12, // 6: mir_api.v1.DevicesCommands.device_commands:type_name -> mir_api.v1.DevicesCommands.DeviceCommandsEntry
-	7,  // 7: mir_api.v1.Commands.commands:type_name -> mir_api.v1.CommandDescriptor
-	13, // 8: mir_api.v1.CommandDescriptor.labels:type_name -> mir_api.v1.CommandDescriptor.LabelsEntry
+	5,  // 5: mir_api.v1.SendListCommandsResponse.ok:type_name -> mir_api.v1.CommandsResponse
+	6,  // 6: mir_api.v1.CommandsResponse.devices_commands:type_name -> mir_api.v1.DevicesCommands
+	7,  // 7: mir_api.v1.DevicesCommands.cmd_descriptors:type_name -> mir_api.v1.CommandDescriptor
+	12, // 8: mir_api.v1.CommandDescriptor.labels:type_name -> mir_api.v1.CommandDescriptor.LabelsEntry
 	10, // 9: mir_api.v1.SendCommandResponse.CommandResponses.device_responses:type_name -> mir_api.v1.SendCommandResponse.CommandResponses.DeviceResponsesEntry
-	15, // 10: mir_api.v1.SendCommandResponse.CommandResponses.encoding:type_name -> mir_api.v1.Encoding
+	14, // 10: mir_api.v1.SendCommandResponse.CommandResponses.encoding:type_name -> mir_api.v1.Encoding
 	0,  // 11: mir_api.v1.SendCommandResponse.CommandResponse.status:type_name -> mir_api.v1.CommandResponseStatus
 	9,  // 12: mir_api.v1.SendCommandResponse.CommandResponses.DeviceResponsesEntry.value:type_name -> mir_api.v1.SendCommandResponse.CommandResponse
-	6,  // 13: mir_api.v1.DevicesCommands.DeviceCommandsEntry.value:type_name -> mir_api.v1.Commands
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_mir_api_v1_cmd_proto_init() }
@@ -871,7 +875,7 @@ func file_mir_api_v1_cmd_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mir_api_v1_cmd_proto_rawDesc), len(file_mir_api_v1_cmd_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   13,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkgs/api/gen/proto/mir_api/v1/tlm.pb.go
+++ b/pkgs/api/gen/proto/mir_api/v1/tlm.pb.go
@@ -220,8 +220,9 @@ func (x *TelemetryResponse) GetDevicesTelemetry() []*DevicesTelemetry {
 type DevicesTelemetry struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	DevicesNamens  []string               `protobuf:"bytes,1,rep,name=devices_namens,json=devicesNamens,proto3" json:"devices_namens,omitempty"`    // List of devices that have this telemetry
-	TlmDescriptors []*TelemetryDescriptor `protobuf:"bytes,2,rep,name=tlm_descriptors,json=tlmDescriptors,proto3" json:"tlm_descriptors,omitempty"` // Array of telemetry descriptor
-	Error          string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`                                         // List of devices with the same error if something went wrong
+	DevicesId      []string               `protobuf:"bytes,2,rep,name=devices_id,json=devicesId,proto3" json:"devices_id,omitempty"`                // List of devices that have this telemetry
+	TlmDescriptors []*TelemetryDescriptor `protobuf:"bytes,3,rep,name=tlm_descriptors,json=tlmDescriptors,proto3" json:"tlm_descriptors,omitempty"` // Array of telemetry descriptor
+	Error          string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`                                         // List of devices with the same error if something went wrong
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -259,6 +260,13 @@ func (*DevicesTelemetry) Descriptor() ([]byte, []int) {
 func (x *DevicesTelemetry) GetDevicesNamens() []string {
 	if x != nil {
 		return x.DevicesNamens
+	}
+	return nil
+}
+
+func (x *DevicesTelemetry) GetDevicesId() []string {
+	if x != nil {
+		return x.DevicesId
 	}
 	return nil
 }
@@ -374,11 +382,13 @@ const file_mir_api_v1_tlm_proto_rawDesc = "" +
 	"\n" +
 	"\bresponse\"^\n" +
 	"\x11TelemetryResponse\x12I\n" +
-	"\x11devices_telemetry\x18\x01 \x03(\v2\x1c.mir_api.v1.DevicesTelemetryR\x10devicesTelemetry\"\x99\x01\n" +
+	"\x11devices_telemetry\x18\x01 \x03(\v2\x1c.mir_api.v1.DevicesTelemetryR\x10devicesTelemetry\"\xb8\x01\n" +
 	"\x10DevicesTelemetry\x12%\n" +
-	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12H\n" +
-	"\x0ftlm_descriptors\x18\x02 \x03(\v2\x1f.mir_api.v1.TelemetryDescriptorR\x0etlmDescriptors\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"\xfc\x01\n" +
+	"\x0edevices_namens\x18\x01 \x03(\tR\rdevicesNamens\x12\x1d\n" +
+	"\n" +
+	"devices_id\x18\x02 \x03(\tR\tdevicesId\x12H\n" +
+	"\x0ftlm_descriptors\x18\x03 \x03(\v2\x1f.mir_api.v1.TelemetryDescriptorR\x0etlmDescriptors\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\xfc\x01\n" +
 	"\x13TelemetryDescriptor\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12C\n" +
 	"\x06labels\x18\x02 \x03(\v2+.mir_api.v1.TelemetryDescriptor.LabelsEntryR\x06labels\x12\x16\n" +

--- a/pkgs/api/proto/mir_api/v1/cfg.proto
+++ b/pkgs/api/proto/mir_api/v1/cfg.proto
@@ -79,8 +79,9 @@ message ConfigsResponse {
 // List of config
 message DevicesConfigs {
     repeated string devices_namens = 1; // List of devices that have this telemetry
-	repeated ConfigDescriptor cfg_descriptors = 2; // Array of config descriptor
-	string error = 3; // error if something went wrong
+    repeated string devices_id = 2; // List of devices that have this telemetry
+	repeated ConfigDescriptor cfg_descriptors = 3; // Array of config descriptor
+	string error = 4; // error if something went wrong
 }
 
 // Descriptor of a config

--- a/pkgs/api/proto/mir_api/v1/cfg.proto
+++ b/pkgs/api/proto/mir_api/v1/cfg.proto
@@ -66,20 +66,21 @@ message SendListConfigRequest {
 
 message SendListConfigResponse {
   oneof response {
-  	DevicesConfigs ok = 1; // all configs per devices
+  	ConfigsResponse ok = 1; // all configs per devices
     string error = 2;  // error if something went wrong
   }
 }
 
 // Map of device id and its list of configs
-message DevicesConfigs {
-	map<string, Configs> device_configs = 1; // all config per devices
+message ConfigsResponse {
+	repeated DevicesConfigs device_configs = 1; // all config per devices
 }
 
 // List of config
-message Configs {
-	repeated ConfigDescriptor configs = 1; // Array of config descriptor
-	string error = 2; // error if something went wrong
+message DevicesConfigs {
+    repeated string devices_namens = 1; // List of devices that have this telemetry
+	repeated ConfigDescriptor cfg_descriptors = 2; // Array of config descriptor
+	string error = 3; // error if something went wrong
 }
 
 // Descriptor of a config

--- a/pkgs/api/proto/mir_api/v1/cmd.proto
+++ b/pkgs/api/proto/mir_api/v1/cmd.proto
@@ -65,20 +65,21 @@ message SendListCommandsRequest {
 
 message SendListCommandsResponse {
   oneof response {
-  	DevicesCommands ok = 1; // all commands per devices
+  	CommandsResponse ok = 1; // all commands per devices
     string error = 2;  // error if something went wrong
   }
 }
 
 // Map of device id and its list of commands
-message DevicesCommands {
-	map<string, Commands> device_commands = 1; // all commands per devices
+message CommandsResponse {
+	repeated DevicesCommands devices_commands = 1; // all commands per devices
 }
 
 // List of commands
-message Commands {
-	repeated CommandDescriptor commands = 1; // Array of command descriptor
-	string error = 2; // HTTP like error if something went wrong
+message DevicesCommands {
+    repeated string devices_namens = 1; // List of devices that have this telemetry
+	repeated CommandDescriptor cmd_descriptors = 2; // Array of command descriptor
+	string error = 3; // HTTP like error if something went wrong
 }
 
 // Descriptor of a command

--- a/pkgs/api/proto/mir_api/v1/cmd.proto
+++ b/pkgs/api/proto/mir_api/v1/cmd.proto
@@ -78,8 +78,9 @@ message CommandsResponse {
 // List of commands
 message DevicesCommands {
     repeated string devices_namens = 1; // List of devices that have this telemetry
-	repeated CommandDescriptor cmd_descriptors = 2; // Array of command descriptor
-	string error = 3; // HTTP like error if something went wrong
+    repeated string devices_id = 2; // List of devices that have this telemetry
+	repeated CommandDescriptor cmd_descriptors = 3; // Array of command descriptor
+	string error = 4; // HTTP like error if something went wrong
 }
 
 // Descriptor of a command

--- a/pkgs/api/proto/mir_api/v1/tlm.proto
+++ b/pkgs/api/proto/mir_api/v1/tlm.proto
@@ -25,8 +25,9 @@ message TelemetryResponse {
 // List of telemetry
 message DevicesTelemetry {
     repeated string devices_namens = 1; // List of devices that have this telemetry
-	repeated TelemetryDescriptor tlm_descriptors = 2; // Array of telemetry descriptor
-	string error = 3;// List of devices with the same error if something went wrong
+    repeated string devices_id = 2; // List of devices that have this telemetry
+	repeated TelemetryDescriptor tlm_descriptors = 3; // Array of telemetry descriptor
+	string error = 4;// List of devices with the same error if something went wrong
 }
 
 // Descriptor of a command

--- a/pkgs/module/mir/server_integration_test.go
+++ b/pkgs/module/mir/server_integration_test.go
@@ -338,9 +338,10 @@ func TestServerRoutes_ListTelemetry(t *testing.T) {
 
 func TestServerRoutes_ListCommand(t *testing.T) {
 	deviceID := "test-server-listcmd"
-	testCommands := map[string]*mir_apiv1.Commands{
-		"test-server-listcmd": {
-			Commands: []*mir_apiv1.CommandDescriptor{
+	testCommands := []*mir_apiv1.DevicesCommands{
+		{
+			DevicesNamens: []string{"test-server-listcmd"},
+			CmdDescriptors: []*mir_apiv1.CommandDescriptor{
 				{
 					Name: "cmd_test",
 				},
@@ -349,7 +350,7 @@ func TestServerRoutes_ListCommand(t *testing.T) {
 	}
 
 	err := m.Client().ListCommands().Subscribe(
-		func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error) {
+		func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error) {
 			return testCommands, nil
 		},
 	)
@@ -361,7 +362,7 @@ func TestServerRoutes_ListCommand(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, resp[deviceID].Commands[0].Name, testCommands[deviceID].Commands[0].Name)
+	assert.Equal(t, resp[0].DevicesNamens[0], testCommands[0].DevicesNamens[0])
 }
 
 func TestServerRoutes_SendCommand(t *testing.T) {

--- a/pkgs/module/mir/server_tlm_cmd_cfg.go
+++ b/pkgs/module/mir/server_tlm_cmd_cfg.go
@@ -108,18 +108,18 @@ func (r *clientRoutes) ListCommands() *listCommandRoute {
 }
 
 // Subscribe to list command request
-func (r *listCommandRoute) Subscribe(f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error)) error {
+func (r *listCommandRoute) Subscribe(f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error)) error {
 	sbj := cmd_client.ListCommandsRequest.WithId("*")
 	return r.m.subscribe(sbj, r.handlerWrapper(f))
 }
 
 // Queue subscribe to list command request
-func (r *listCommandRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error)) error {
+func (r *listCommandRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error)) error {
 	sbj := cmd_client.ListCommandsRequest.WithId("*")
 	return r.m.queueSubscribe(queue, sbj, r.handlerWrapper(f))
 }
 
-func (r *listCommandRoute) handlerWrapper(f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error)) nats.MsgHandler {
+func (r *listCommandRoute) handlerWrapper(f func(msg *Msg, clientId string, req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error)) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		req := &mir_apiv1.SendListCommandsRequest{}
 		if err := proto.Unmarshal(msg.Data, req); err != nil {
@@ -141,8 +141,8 @@ func (r *listCommandRoute) handlerWrapper(f func(msg *Msg, clientId string, req 
 		// TODO log error here
 		err = r.m.sendReplyOrAck(msg, &mir_apiv1.SendListCommandsResponse{
 			Response: &mir_apiv1.SendListCommandsResponse_Ok{
-				Ok: &mir_apiv1.DevicesCommands{
-					DeviceCommands: resp,
+				Ok: &mir_apiv1.CommandsResponse{
+					DevicesCommands: resp,
 				},
 			},
 		})
@@ -155,28 +155,28 @@ func (r *listCommandRoute) handlerWrapper(f func(msg *Msg, clientId string, req 
 }
 
 // Request listing of command per device
-func (r *listCommandRoute) Request(req *mir_apiv1.SendListCommandsRequest) (map[string]*mir_apiv1.Commands, error) {
+func (r *listCommandRoute) Request(req *mir_apiv1.SendListCommandsRequest) ([]*mir_apiv1.DevicesCommands, error) {
 	sbj := cmd_client.ListCommandsRequest.WithId(r.m.GetInstanceName())
 	bReq, err := proto.Marshal(req)
 	if err != nil {
-		return map[string]*mir_apiv1.Commands{}, err
+		return []*mir_apiv1.DevicesCommands{}, err
 	}
 
 	resMsg, err := r.m.request(sbj, bReq, nil, defaultTimeout)
 	if err != nil {
-		return map[string]*mir_apiv1.Commands{}, err
+		return []*mir_apiv1.DevicesCommands{}, err
 	}
 
 	resp := &mir_apiv1.SendListCommandsResponse{}
 	err = proto.Unmarshal(resMsg.Data, resp)
 	if err != nil {
-		return map[string]*mir_apiv1.Commands{}, err
+		return []*mir_apiv1.DevicesCommands{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.Commands{}, errors.New(resp.GetError())
+		return []*mir_apiv1.DevicesCommands{}, errors.New(resp.GetError())
 	}
 
-	return resp.GetOk().DeviceCommands, nil
+	return resp.GetOk().DevicesCommands, nil
 }
 
 /// SendCommand

--- a/pkgs/module/mir/server_tlm_cmd_cfg.go
+++ b/pkgs/module/mir/server_tlm_cmd_cfg.go
@@ -298,18 +298,18 @@ func (r *clientRoutes) ListConfig() *listConfigurationRoute {
 }
 
 // Subscribe to list command request
-func (r *listConfigurationRoute) Subscribe(f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error)) error {
+func (r *listConfigurationRoute) Subscribe(f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) ([]*mir_apiv1.DevicesConfigs, error)) error {
 	sbj := cfg_client.ListConfigRequest.WithId("*")
 	return r.m.subscribe(sbj, r.handlerWrapper(f))
 }
 
 // Queue subscribe to list command request
-func (r *listConfigurationRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error)) error {
+func (r *listConfigurationRoute) QueueSubscribe(queue string, f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) ([]*mir_apiv1.DevicesConfigs, error)) error {
 	sbj := cfg_client.ListConfigRequest.WithId("*")
 	return r.m.queueSubscribe(queue, sbj, r.handlerWrapper(f))
 }
 
-func (r *listConfigurationRoute) handlerWrapper(f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error)) nats.MsgHandler {
+func (r *listConfigurationRoute) handlerWrapper(f func(msg *Msg, clientId string, req *mir_apiv1.SendListConfigRequest) ([]*mir_apiv1.DevicesConfigs, error)) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		req := &mir_apiv1.SendListConfigRequest{}
 		if err := proto.Unmarshal(msg.Data, req); err != nil {
@@ -331,7 +331,7 @@ func (r *listConfigurationRoute) handlerWrapper(f func(msg *Msg, clientId string
 		// TODO log error here
 		err = r.m.sendReplyOrAck(msg, &mir_apiv1.SendListConfigResponse{
 			Response: &mir_apiv1.SendListConfigResponse_Ok{
-				Ok: &mir_apiv1.DevicesConfigs{
+				Ok: &mir_apiv1.ConfigsResponse{
 					DeviceConfigs: resp,
 				},
 			},
@@ -345,25 +345,25 @@ func (r *listConfigurationRoute) handlerWrapper(f func(msg *Msg, clientId string
 }
 
 // Request listing of command per device
-func (r *listConfigurationRoute) Request(req *mir_apiv1.SendListConfigRequest) (map[string]*mir_apiv1.Configs, error) {
+func (r *listConfigurationRoute) Request(req *mir_apiv1.SendListConfigRequest) ([]*mir_apiv1.DevicesConfigs, error) {
 	sbj := cfg_client.ListConfigRequest.WithId(r.m.GetInstanceName())
 	bReq, err := proto.Marshal(req)
 	if err != nil {
-		return map[string]*mir_apiv1.Configs{}, err
+		return []*mir_apiv1.DevicesConfigs{}, err
 	}
 
 	resMsg, err := r.m.request(sbj, bReq, nil, defaultTimeout)
 	if err != nil {
-		return map[string]*mir_apiv1.Configs{}, err
+		return []*mir_apiv1.DevicesConfigs{}, err
 	}
 
 	resp := &mir_apiv1.SendListConfigResponse{}
 	err = proto.Unmarshal(resMsg.Data, resp)
 	if err != nil {
-		return map[string]*mir_apiv1.Configs{}, err
+		return []*mir_apiv1.DevicesConfigs{}, err
 	}
 	if resp.GetError() != "" {
-		return map[string]*mir_apiv1.Configs{}, errors.New(resp.GetError())
+		return []*mir_apiv1.DevicesConfigs{}, errors.New(resp.GetError())
 	}
 
 	return resp.GetOk().DeviceConfigs, nil


### PR DESCRIPTION
## Summary

- Implemented TUI command interface for sending commands to devices
- Updated command API to group devices with identical schemas together
- Added new command list page with interactive menu
- Enhanced protocol command server to optimize command listing by schema

## Changes

### API Changes
- Modified `SendListCommandsResponse` to use `CommandsResponse` structure
- Changed from map-based device commands to array-based `DevicesCommands`
- Groups devices with the same schema to reduce redundancy

### Server Implementation
- Updated `ProtoCmdServer.listCommandsSub()` to combine devices with identical schemas
- Improved error handling and grouping for devices
- Added schema comparison logic using `mir_proto.AreSchemaEqual()`

### TUI Implementation
- Created new command page at `internal/ui/tui/pages/device/cmd/`
- Added `DeviceCommandListedMsg` message type for command list updates
- Integrated command list view with group menu component
- Added routing from device list page (key: 'r')

### Testing
- Updated integration tests to reflect new API structure
- Tests now validate `DevicesCommands` array instead of map

## Test Plan

- [x] Command listing groups devices with same schema correctly
- [x] Integration tests pass with new API structure
- [x] TUI navigation to command page works from device list
- [x] Error handling for devices without schemas
- [x] Multiple devices with different schemas display separately

## Related Tasks

This PR addresses the "Road to Production" feature from TASKS.md:
- TUI → Cmd (Command interface)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>