### PR TITLE
Added cmd widget and general improvements

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -19,6 +19,7 @@
   - [x] dashboard toolbar, horizontal scroll
   - [x] tlm, autorefresh and timerange
   - [x] tlm, utc switch
+  - [ ] store, validate CONTAINS with *
   - [ ] dev
   - [ ] cmd
   - [ ] cfg

--- a/docs/superpowers/plans/2026-03-31-cmd-widget.md
+++ b/docs/superpowers/plans/2026-03-31-cmd-widget.md
@@ -1,0 +1,630 @@
+# Command Widget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite `widget-command.svelte` to support multi-device command dispatch with grouped descriptor panel, broadcast + per-device send modes, inline response log, view state persistence, and fullscreen — mirroring the quality of `widget-telemetry.svelte`.
+
+**Architecture:** `DescriptorPanel` in grouped mode on the left; `JsonPayloadEditor` + response log on the right. On load, all targeted devices are resolved via one `listCommands()` call. Send fans out per device with `Promise.allSettled`. Three files change: the widget (full rewrite), the config type (add `selectedCommand?`), and the grid (wire `onDevicesReady`).
+
+**Tech Stack:** Svelte 5, TypeScript, `@mir/sdk` (`CommandGroup`, `CommandDescriptor`, `CommandResponseStatus`, `DeviceTarget`), CodeMirror (via `JsonPayloadEditor`), Lucide icons, TailwindCSS.
+
+---
+
+### Key Types (reference for all tasks)
+
+From `@mir/sdk`:
+```ts
+type DeviceId = { id: string; name: string; namespace: string };
+
+type CommandGroup = {
+    ids: DeviceId[];
+    descriptors: CommandDescriptor[];
+    error: string;
+};
+
+type CommandDescriptor = {
+    name: string;
+    labels: Record<string, string>;
+    template: string;
+    error: string;
+};
+
+type SendCommandResult = Map<string, CommandResponse>;
+
+type CommandResponse = {
+    deviceId: string;
+    name: string;
+    payload: Uint8Array;
+    status: CommandResponseStatus;
+    error: string;
+};
+
+enum CommandResponseStatus {
+    UNSPECIFIED = 0,
+    PENDING = 1,
+    VALIDATED = 2,
+    ERROR = 3,
+    SUCCESS = 4
+}
+```
+
+From `$lib/domains/devices/types/types`:
+```ts
+type Descriptor = {
+    name: string;
+    labels: Record<string, string>;
+    template: string;
+    error: string;
+};
+// CommandDescriptor is structurally identical to Descriptor — they are compatible.
+```
+
+---
+
+### Task 1: Update `CommandWidgetConfig` type
+
+**Files:**
+- Modify: `internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts`
+
+- [ ] **Step 1: Add `selectedCommand` view-state field**
+
+Open `dashboard-api.ts`. Find the `CommandWidgetConfig` interface (currently lines 22–24) and add `selectedCommand?`:
+
+```ts
+export interface CommandWidgetConfig {
+	target: DeviceTargetConfig;
+	selectedCommand?: string;
+}
+```
+
+- [ ] **Step 2: Verify type check passes**
+
+```bash
+cd internal/ui/web && npm run check 2>&1 | grep -E "error|warning" | head -20
+```
+
+Expected: no new errors (3 pre-existing errors in `nav-section.svelte` and `multi/telemetry` are OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
+git commit -m "feat(dashboard): add selectedCommand view-state field to CommandWidgetConfig"
+```
+
+---
+
+### Task 2: Wire `onDevicesReady` in `dashboard-grid.svelte`
+
+**Files:**
+- Modify: `internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte`
+
+- [ ] **Step 1: Add `widgetId` and `onDevicesReady` to the `<WidgetCommand>` invocation**
+
+Find this block in `dashboard-grid.svelte` (currently around line 108):
+```svelte
+{:else if widget.type === 'command'}
+    <WidgetCommand config={widget.config as CommandWidgetConfig} />
+```
+
+Replace it with:
+```svelte
+{:else if widget.type === 'command'}
+    <WidgetCommand
+        widgetId={widget.id}
+        config={widget.config as CommandWidgetConfig}
+        onDevicesReady={(infos) => widgetDevices.set(widget.id, infos)}
+    />
+```
+
+- [ ] **Step 2: Verify type check passes**
+
+```bash
+cd internal/ui/web && npm run check 2>&1 | grep -E "error|warning" | head -20
+```
+
+Expected: TypeScript will complain that `WidgetCommand` doesn't have `widgetId`/`onDevicesReady` props yet — that's fine, it will be resolved in Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte
+git commit -m "feat(dashboard): wire widgetId and onDevicesReady to WidgetCommand in grid"
+```
+
+---
+
+### Task 3: Rewrite `widget-command.svelte`
+
+**Files:**
+- Modify (full rewrite): `internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte`
+
+- [ ] **Step 1: Replace the entire file with the new implementation**
+
+```svelte
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { mirStore } from '$lib/domains/mir/stores/mir.svelte';
+	import { DescriptorPanel, JsonPayloadEditor } from '$lib/domains/devices/components/commands';
+	import { DeviceTarget } from '@mir/sdk';
+	import type { CommandDescriptor, CommandGroup } from '@mir/sdk';
+	import { CommandResponseStatus } from '@mir/sdk';
+	import { activityStore } from '$lib/domains/activity/stores/activity.svelte';
+	import { dashboardStore } from '$lib/domains/dashboards/stores/dashboard.svelte';
+	import { CHART_COLORS } from '$lib/domains/devices/utils/tlm-time';
+	import type { CommandWidgetConfig } from '../api/dashboard-api';
+	import MaximizeIcon from '@lucide/svelte/icons/maximize';
+	import MinimizeIcon from '@lucide/svelte/icons/minimize';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import XCircleIcon from '@lucide/svelte/icons/x-circle';
+
+	let {
+		config,
+		widgetId,
+		onDevicesReady
+	}: {
+		config: CommandWidgetConfig;
+		widgetId: string;
+		onDevicesReady?: (infos: { id: string; name: string; color: string }[]) => void;
+	} = $props();
+
+	// ─── Types ────────────────────────────────────────────────────────────────
+
+	type CmdResponseEntry = {
+		deviceId: string;
+		deviceName: string;
+		status: 'success' | 'error';
+		message: string;
+		durationMs: number;
+		expanded: boolean;
+	};
+
+	// ─── State ────────────────────────────────────────────────────────────────
+
+	let groups = $state<CommandGroup[]>([]);
+	let isLoading = $state(false);
+	let loadError = $state<string | null>(null);
+	let hasLoaded = $state(false);
+
+	let selectedGroupIdx = $state<number | null>(null);
+	let selectedCommand = $state<CommandDescriptor | null>(null);
+	let editorContent = $state('{}');
+
+	let isSending = $state(false);
+	let sendError = $state<string | null>(null);
+	let responses = $state<CmdResponseEntry[]>([]);
+	let hasResponses = $state(false);
+
+	let fullscreen = $state(false);
+
+	// ─── Derived ──────────────────────────────────────────────────────────────
+
+	const selectedKey = $derived(
+		selectedGroupIdx !== null && selectedCommand
+			? `${selectedGroupIdx}:${selectedCommand.name}`
+			: null
+	);
+
+	const descriptorGroups = $derived(
+		groups.map((g) => ({
+			label: g.ids.map((d) => `${d.name}/${d.namespace}`).join(', '),
+			items: g.descriptors,
+			errors: g.error ? [g.error] : []
+		}))
+	);
+
+	const groupErrors = $derived(groups.map((g) => g.error).filter(Boolean) as string[]);
+
+	const selectedGroupDevices = $derived(
+		selectedGroupIdx !== null ? (groups[selectedGroupIdx]?.ids ?? []) : []
+	);
+
+	const deviceValues = $derived.by(() => {
+		if (selectedGroupDevices.length <= 1) return undefined;
+		return selectedGroupDevices.map((d) => ({
+			label: `${d.name}/${d.namespace}`,
+			deviceId: d.id,
+			values: editorContent
+		}));
+	});
+
+	// ─── Startup ──────────────────────────────────────────────────────────────
+
+	$effect(() => {
+		if (mirStore.mir) {
+			untrack(loadCommands);
+		} else {
+			groups = [];
+			loadError = null;
+		}
+	});
+
+	async function loadCommands() {
+		const mir = mirStore.mir;
+		if (!mir) return;
+
+		isLoading = true;
+		loadError = null;
+		groups = [];
+		selectedCommand = null;
+		selectedGroupIdx = null;
+		responses = [];
+		hasResponses = false;
+
+		try {
+			const target = new DeviceTarget({
+				ids: config.target.ids,
+				namespaces: config.target.namespaces,
+				labels: config.target.labels
+			});
+			groups = await mir.client().listCommands().request(target);
+
+			const allDevices = groups.flatMap((g) => g.ids);
+			onDevicesReady?.(
+				allDevices.map((d, i) => ({
+					id: d.id,
+					name: d.name,
+					color: CHART_COLORS[i % CHART_COLORS.length]
+				}))
+			);
+
+			// Restore selected command from view state
+			if (config.selectedCommand) {
+				for (let gi = 0; gi < groups.length; gi++) {
+					const desc = groups[gi].descriptors.find((d) => d.name === config.selectedCommand);
+					if (desc) {
+						selectCommand(gi, desc);
+						break;
+					}
+				}
+			}
+		} catch (err) {
+			loadError = err instanceof Error ? err.message : 'Failed to load commands';
+		} finally {
+			isLoading = false;
+			hasLoaded = true;
+		}
+	}
+
+	// ─── Selection ────────────────────────────────────────────────────────────
+
+	function selectCommand(groupIdx: number, desc: CommandDescriptor) {
+		selectedGroupIdx = groupIdx;
+		selectedCommand = desc;
+		try {
+			editorContent = JSON.stringify(JSON.parse(desc.template || '{}'), null, 2);
+		} catch {
+			editorContent = desc.template || '{}';
+		}
+		isSending = false;
+		sendError = null;
+		responses = [];
+		hasResponses = false;
+	}
+
+	// ─── View state ───────────────────────────────────────────────────────────
+
+	$effect(() => {
+		if (!hasLoaded) return;
+		const name = selectedCommand?.name;
+		untrack(() => {
+			dashboardStore.saveWidgetViewState(widgetId, {
+				...config,
+				selectedCommand: name
+			});
+		});
+	});
+
+	// ─── Send helpers ─────────────────────────────────────────────────────────
+
+	function isResponseSuccess(status: CommandResponseStatus): boolean {
+		return status === CommandResponseStatus.SUCCESS || status === CommandResponseStatus.VALIDATED;
+	}
+
+	function responseMessage(status: CommandResponseStatus, error: string): string {
+		if (error) return error;
+		return CommandResponseStatus[status] ?? 'OK';
+	}
+
+	async function sendToDevice(
+		mir: NonNullable<typeof mirStore.mir>,
+		deviceId: string,
+		deviceName: string,
+		text: string,
+		dryRun: boolean
+	): Promise<CmdResponseEntry> {
+		const start = performance.now();
+		try {
+			const target = new DeviceTarget({ ids: [deviceId] });
+			const result = await mir
+				.client()
+				.sendCommand()
+				.request(target, selectedCommand!.name, text, dryRun);
+			const durationMs = Math.round(performance.now() - start);
+			const resp = result.get(deviceId) ?? [...result.values()][0];
+			const success = resp ? isResponseSuccess(resp.status) : true;
+			const message = resp ? responseMessage(resp.status, resp.error) : 'OK';
+			activityStore.add({
+				kind: success ? 'success' : 'error',
+				category: 'Command',
+				title: selectedCommand!.name,
+				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				...(success ? { response: Object.fromEntries(result) } : { error: message })
+			});
+			return { deviceId, deviceName, status: success ? 'success' : 'error', message, durationMs, expanded: false };
+		} catch (err) {
+			const durationMs = Math.round(performance.now() - start);
+			const message = err instanceof Error ? err.message : 'Failed';
+			activityStore.add({
+				kind: 'error',
+				category: 'Command',
+				title: selectedCommand!.name,
+				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				error: message
+			});
+			return { deviceId, deviceName, status: 'error', message, durationMs, expanded: false };
+		}
+	}
+
+	// ─── Send (broadcast) ─────────────────────────────────────────────────────
+
+	async function handleSend(dryRun: boolean, text: string) {
+		const mir = mirStore.mir;
+		if (!mir || !selectedCommand || selectedGroupDevices.length === 0) return;
+
+		isSending = true;
+		sendError = null;
+		responses = [];
+		hasResponses = true;
+
+		const results = await Promise.allSettled(
+			selectedGroupDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
+		);
+
+		responses = results.map((r) =>
+			r.status === 'fulfilled'
+				? r.value
+				: {
+						deviceId: '',
+						deviceName: 'unknown',
+						status: 'error' as const,
+						message: String(r.reason),
+						durationMs: 0,
+						expanded: false
+					}
+		);
+
+		isSending = false;
+	}
+
+	// ─── Send (per-device) ────────────────────────────────────────────────────
+
+	async function handleSendMulti(dryRun: boolean, payloads: Map<string, string>) {
+		const mir = mirStore.mir;
+		if (!mir || !selectedCommand) return;
+
+		isSending = true;
+		sendError = null;
+		responses = [];
+		hasResponses = true;
+
+		const results = await Promise.allSettled(
+			[...payloads.entries()].map(([deviceId, text]) => {
+				const dev =
+					selectedGroupDevices.find((d) => d.id === deviceId) ??
+					({ id: deviceId, name: deviceId, namespace: 'default' } as const);
+				return sendToDevice(mir, dev.id, dev.name, text, dryRun);
+			})
+		);
+
+		responses = results.map((r) =>
+			r.status === 'fulfilled'
+				? r.value
+				: {
+						deviceId: '',
+						deviceName: 'unknown',
+						status: 'error' as const,
+						message: String(r.reason),
+						durationMs: 0,
+						expanded: false
+					}
+		);
+
+		isSending = false;
+	}
+</script>
+
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape' && fullscreen) fullscreen = false;
+	}}
+/>
+
+<div
+	class="{fullscreen
+		? 'fixed inset-0 z-50 bg-background'
+		: 'h-full'} flex flex-col overflow-hidden"
+>
+	{#if loadError}
+		<p class="px-4 py-2 text-xs text-destructive">{loadError}</p>
+	{:else}
+		<div class="flex min-h-0 flex-1 overflow-hidden">
+			<!-- Left: command list -->
+			<DescriptorPanel
+				title="Commands"
+				items={[]}
+				{isLoading}
+				error={null}
+				{groupErrors}
+				groups={descriptorGroups}
+				onSelect={() => {}}
+				onSelectGrouped={(gi, desc) => selectCommand(gi, desc)}
+				selectedKey={selectedKey}
+				emptyText="No commands."
+			/>
+
+			<!-- Right: editor + responses -->
+			<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+				{#if selectedCommand}
+					<!-- Fullscreen toggle -->
+					<div class="flex shrink-0 items-center justify-end px-2 py-0.5">
+						<button
+							onclick={() => (fullscreen = !fullscreen)}
+							title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+							class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+						>
+							{#if fullscreen}
+								<MinimizeIcon class="size-3.5" />
+							{:else}
+								<MaximizeIcon class="size-3.5" />
+							{/if}
+						</button>
+					</div>
+
+					<!-- JSON editor -->
+					<div class="flex min-h-0 flex-1 overflow-hidden">
+						<JsonPayloadEditor
+							name={selectedCommand.name}
+							value={editorContent}
+							hasResponse={false}
+							{isSending}
+							{sendError}
+							{deviceValues}
+							onSend={handleSend}
+							onSendMulti={handleSendMulti}
+						/>
+					</div>
+
+					<!-- Response log (appears after first send) -->
+					{#if hasResponses}
+						<div class="max-h-48 shrink-0 overflow-y-auto border-t">
+							<div class="border-b px-3 py-1">
+								<span
+									class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+									>Responses</span
+								>
+							</div>
+							{#each responses as entry (entry.deviceId + entry.deviceName)}
+								<div class="border-b last:border-0">
+									<button
+										class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/50"
+										onclick={() => (entry.expanded = !entry.expanded)}
+									>
+										{#if entry.status === 'success'}
+											<CheckIcon class="size-3 shrink-0 text-emerald-500" />
+										{:else}
+											<XCircleIcon class="size-3 shrink-0 text-destructive" />
+										{/if}
+										<span class="min-w-0 flex-1 truncate font-mono text-xs"
+											>{entry.deviceName}</span
+										>
+										<span class="shrink-0 font-mono text-[10px] text-muted-foreground"
+											>{entry.durationMs}ms</span
+										>
+										<span
+											class="max-w-32 truncate font-mono text-[10px] text-muted-foreground"
+											>{entry.message}</span
+										>
+									</button>
+									{#if entry.expanded}
+										<pre
+											class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.message}</pre>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+				{:else}
+					<p class="p-4 text-xs text-muted-foreground">Select a command</p>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+```
+
+- [ ] **Step 2: Run type check**
+
+```bash
+cd internal/ui/web && npm run check 2>&1 | grep -E "Error|error TS" | grep -v "nav-section\|multi/telemetry"
+```
+
+Expected: no new errors. If `CHART_COLORS` import fails (path not found), use the fallback:
+
+```ts
+// Replace the CHART_COLORS import + usage with:
+const FALLBACK_COLORS = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
+// and in onDevicesReady:
+color: FALLBACK_COLORS[i % FALLBACK_COLORS.length]
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+git commit -m "feat(dashboard): rewrite cmd widget with multi-device, per-device send, and response log"
+```
+
+---
+
+### Task 4: Smoke test and final type check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full type check**
+
+```bash
+cd internal/ui/web && npm run check 2>&1 | tail -5
+```
+
+Expected output ends with something like:
+```
+svelte-check found 0 errors, 3 warnings
+```
+(The 3 warnings are pre-existing in `nav-section.svelte` and `multi/telemetry`.)
+
+- [ ] **Step 2: Start dev server and manually verify**
+
+```bash
+cd internal/ui/web && npm run dev
+```
+
+Open the dashboard, add a Command widget targeting ≥1 device that has commands registered. Verify:
+
+1. Command list loads in the left panel (grouped by schema if multiple devices)
+2. Device pills appear in the widget header
+3. Selecting a command populates the editor with the JSON template
+4. Clicking **Send** dispatches to all devices in the group and shows the response log below
+5. With multiple devices, clicking **PER DEVICE** in the editor header switches to per-device mode; each device gets its own editable JSON block; clicking **Send** dispatches individual payloads
+6. Clicking **Dry Run** sends with `dryRun: true`; responses appear in the log
+7. Click a response entry — it expands to show the full message
+8. The fullscreen button (top-right of editor area) toggles fullscreen; Escape exits it
+9. Reload the page — the previously selected command is restored
+
+- [ ] **Step 3: Commit if any fixes were needed from manual testing**
+
+```bash
+git add internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+git commit -m "fix(cmd-widget): address issues found during manual smoke test"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- ✅ Multi-device support — `CommandGroup.ids[]` drives all device operations
+- ✅ Broadcast mode — `handleSend` fans out same text to all group devices
+- ✅ Per-device mode — `handleSendMulti` receives per-device payloads from `JsonPayloadEditor`
+- ✅ Response log — `responses: CmdResponseEntry[]`, `hasResponses` flag, expand on click
+- ✅ Device pills — `onDevicesReady` prop wired in `dashboard-grid.svelte`
+- ✅ View state — `selectedCommand` saved via `saveWidgetViewState`, restored on load
+- ✅ Fullscreen — `fixed inset-0 z-50 bg-background`, Escape exits
+- ✅ `CommandWidgetConfig.selectedCommand?` added in Task 1
+- ✅ `dashboard-grid.svelte` wired in Task 2
+
+**Type consistency:**
+- `sendToDevice()` defined in Task 3 script, called in `handleSend` and `handleSendMulti` — same name throughout
+- `CmdResponseEntry` defined locally in the widget — no external dependency
+- `CommandResponseStatus` imported from `@mir/sdk` — matches enum values used in `isResponseSuccess()`
+- `descriptorGroups` items have type `{ label, items: CommandDescriptor[], errors? }` — `CommandDescriptor` is structurally identical to `Descriptor` so `DescriptorPanel` accepts it without cast

--- a/docs/superpowers/specs/2026-03-30-device-sdk-c-design.md
+++ b/docs/superpowers/specs/2026-03-30-device-sdk-c-design.md
@@ -1,0 +1,327 @@
+# Mir Device SDK — C Design Spec
+
+**Date:** 2026-03-30  
+**Author:** MaxThom  
+**Status:** Approved  
+
+---
+
+## Overview
+
+A standalone C SDK (`mir-ecosystem/mir.sdk.c`) that allows IoT devices to connect to a Mir IoT Hub server. It targets both microcontrollers (MCUs) and embedded Linux, supports full feature parity with the Go SDK (including schema upload via protobuf `FileDescriptorSet`), and is callable from C++ via `extern "C"` headers with future Python bindings via `ctypes`.
+
+---
+
+## Goals
+
+- Connect devices to Mir over NATS (TLS + credentials auth)
+- Send telemetry and reported properties (protobuf bytes)
+- Receive and handle commands and configuration updates
+- Send device schema (`FileDescriptorSet`) on boot
+- Heartbeat every 10 seconds
+- Offline message buffering (resend on reconnect)
+- Run on ESP32 (and similar MCUs with ≥64KB RAM) and embedded Linux
+- Usable from C++ via `extern "C"` header guards (no separate C++ wrapper)
+- Python bindings via `ctypes` against the compiled `.so`
+
+## Non-Goals
+
+- Sub-64KB RAM MCUs (STM32F0-class) — not in scope for v1
+- Native C++ wrapper classes (RAII, templates) — deferred
+- Auto-provisioning / device ID generation from hardware — deferred
+- Module SDK in C — device SDK only
+
+---
+
+## Architecture
+
+Four layers. Each layer only depends on the one below it.
+
+```
+┌────────────────────────────────────────────────┐
+│  Public C API  (mir_device.h)                  │  ← User code
+│  Device lifecycle, telemetry, commands, config  │
+├────────────────────────────────────────────────┤
+│  SDK Core                                      │  ← Heartbeat, routing,
+│  mir_device.c / mir_handlers.c / mir_schema.c  │    schema, offline store
+├────────────────────────────────────────────────┤
+│  Transport  (NATS)                             │  ← nats.c on Linux,
+│  mir_transport.h + platform implementations   │    custom client on MCU
+├────────────────────────────────────────────────┤
+│  HAL  (mir_hal.h)                              │  ← Network, time, memory,
+│  linux/mir_hal_linux.c                         │    storage — swapped per
+│  esp32/mir_hal_esp32.c                         │    platform at compile time
+└────────────────────────────────────────────────┘
+```
+
+---
+
+## HAL Interface
+
+The HAL (`mir_hal.h`) is a struct of function pointers — the C equivalent of an interface. The SDK core never calls platform APIs directly; it always goes through the HAL.
+
+```c
+typedef struct {
+    // Network
+    int      (*net_connect)(void *ctx, const char *host, uint16_t port);
+    int      (*net_write)(void *ctx, const uint8_t *buf, size_t len);
+    int      (*net_read)(void *ctx, uint8_t *buf, size_t len, uint32_t timeout_ms);
+    void     (*net_close)(void *ctx);
+
+    // Time
+    uint64_t (*time_ms)(void *ctx);
+
+    // Memory
+    void*    (*mem_alloc)(size_t size);
+    void     (*mem_free)(void *ptr);
+
+    // Offline store (key-value, optional — set to NULL to disable)
+    int      (*store_write)(void *ctx, const char *key, const uint8_t *data, size_t len);
+    int      (*store_read)(void *ctx, const char *key, uint8_t *buf, size_t *len);
+    int      (*store_delete)(void *ctx, const char *key);
+
+    void     *ctx;  // platform-specific state (socket fd, file handle, etc.)
+} mir_hal_t;
+```
+
+Platforms provide pre-built HAL instances:
+- `mir_hal_linux_default()` — TCP sockets, POSIX time, malloc/free, file-based store
+- `mir_hal_esp32_default()` — esp_tls, FreeRTOS tick, heap, SPIFFS/LittleFS store
+
+---
+
+## Public API
+
+```c
+// Configuration
+typedef struct {
+    const char      *device_id;
+    const char      *target;        // "nats://host:4222"
+    const char      *credentials;   // file path to .creds file; NULL on MCU (creds embedded at compile time)
+    const char      *root_ca;       // file path to ca.crt; NULL to skip server verification
+    const char      *tls_cert;      // file path to tls.crt; NULL if not using mTLS
+    const char      *tls_key;       // file path to tls.key; NULL if not using mTLS
+    mir_log_level_t  log_level;
+    mir_store_opts_t store;
+} mir_config_t;
+
+// Lifecycle
+mir_device_t *mir_device_create(const mir_config_t *cfg, const mir_hal_t *hal);
+void          mir_device_destroy(mir_device_t *dev);
+int           mir_device_launch(mir_device_t *dev);
+void          mir_device_shutdown(mir_device_t *dev);
+
+// Schema (pre-serialized FileDescriptorSet, generated at build time)
+void mir_device_set_schema(mir_device_t *dev, const uint8_t *bytes, size_t len);
+
+// Handlers — register before launch
+typedef void (*mir_cmd_handler_fn)(const uint8_t *proto_bytes, size_t len, void *ctx);
+typedef void (*mir_cfg_handler_fn)(const uint8_t *proto_bytes, size_t len, void *ctx);
+void mir_device_handle_command   (mir_device_t *dev, const char *msg_name, mir_cmd_handler_fn fn, void *ctx);
+void mir_device_handle_properties(mir_device_t *dev, const char *msg_name, mir_cfg_handler_fn fn, void *ctx);
+
+// Send
+int mir_device_send_telemetry  (mir_device_t *dev, const char *msg_name, const uint8_t *bytes, size_t len);
+int mir_device_send_properties (mir_device_t *dev, const char *msg_name, const uint8_t *bytes, size_t len);
+```
+
+All functions return `0` on success, negative errno-style codes on failure. The API is wrapped in `extern "C"` so C++ code can include it without any changes.
+
+---
+
+## Protobuf Strategy
+
+**Library:** [protobuf-c](https://github.com/protobuf-c/protobuf-c)
+
+- `protoc-gen-c` generates `.pb-c.h` / `.pb-c.c` from `.proto` files
+- User fills generated C structs, packs to bytes with `my_msg__pack()`, passes bytes to SDK
+- SDK treats telemetry/command payloads as opaque bytes — it does not parse them
+- `msg_name` (the protobuf full name, e.g. `"my_schema.v1.MyTelemetry"`) is passed as a string alongside bytes and set as a NATS message header (matching the Go SDK's `HeaderMsgName` convention)
+
+---
+
+## Schema Upload (FileDescriptorSet)
+
+On `mir_device_launch()`, the SDK sends the device's full protobuf schema to the server — identical behaviour to the Go SDK.
+
+**Build-time flow:**
+
+```
+proto/my_schema.proto
+        │
+        ├─► protoc --plugin=protoc-gen-c
+        │         gen/my_schema.pb-c.h   (C structs for firmware)
+        │         gen/my_schema.pb-c.c   (compiled into firmware)
+        │
+        └─► protoc --descriptor_set_out=schema.bin
+                    │
+                    ▼
+              tools/schema_embed/schema_embed.py
+                    │
+                    ▼
+              gen/my_schema_bytes.h
+              // auto-generated
+              const uint8_t schema_bytes[] = { 0x0a, 0x2c, ... };
+              const size_t  schema_len = 312;
+```
+
+`schema_embed.py` is a ~50-line Python script that reads `schema.bin` and emits the `.h` byte array. CMake runs it automatically via `mir_generate_schema()` — device developers never invoke it manually.
+
+The schema bytes are passed to the SDK with `mir_device_set_schema()` before launch.
+
+---
+
+## NATS Transport
+
+**Linux:** wraps [nats.c](https://github.com/nats-io/nats.c) — full feature set, TLS, credentials.
+
+**MCU (custom minimal client):** NATS protocol is simple line-based text over TCP. The custom client implements:
+- `CONNECT` (with auth token / credentials)
+- `PUB` (publish with headers)
+- `SUB` / `UNSUB`
+- `MSG` (receive)
+- `PING` / `PONG`
+- Reconnect loop
+
+The custom client uses the HAL for all network I/O and is approximately 500–800 lines of C. It does not support JetStream — only core NATS, which is all the Mir SDK requires.
+
+Both transport implementations satisfy a common `mir_transport_t` interface (struct of function pointers), identical in shape to the HAL pattern.
+
+---
+
+## Offline Store
+
+When disconnected, outgoing messages are buffered and replayed on reconnect — matching Go SDK behaviour.
+
+- **Linux:** file-based queue in a configurable directory (default `~/.local/share/mir/<device_id>/`)
+- **ESP32:** SPIFFS or LittleFS ring buffer via the HAL `store_*` functions
+- **Disabled:** set `store_write = NULL` in the HAL to disable buffering (messages are dropped while offline)
+
+Store is keyed by a sequence number. On reconnect, the SDK reads pending messages in order, publishes them, then deletes them.
+
+---
+
+## Build System
+
+**CMake** is the primary build system. A `library.json` is provided for PlatformIO (ESP32 Arduino ecosystem).
+
+```cmake
+# User's CMakeLists.txt
+find_package(mir_sdk REQUIRED)
+
+mir_generate_schema(
+    PROTO_FILES   proto/my_schema.proto
+    OUTPUT_DIR    ${CMAKE_BINARY_DIR}/gen
+)
+
+target_link_libraries(my_firmware PRIVATE mir_sdk::device)
+```
+
+Platform is selected at configure time:
+```bash
+cmake -DMIR_PLATFORM=linux ..    # default
+cmake -DMIR_PLATFORM=esp32 ..
+```
+
+The `proto/mir/device/v1/mir.proto` submodule must be initialized before calling `mir_generate_schema()`:
+```bash
+git submodule update --init
+```
+
+---
+
+## Repository Structure
+
+```
+mir.sdk.c/
+├── include/mir/
+│   ├── mir_device.h       # public API (extern "C" wrapped)
+│   ├── mir_hal.h          # HAL interface
+│   └── mir_types.h        # enums, error codes
+├── src/
+│   ├── core/
+│   │   ├── mir_device.c   # lifecycle, launch, shutdown
+│   │   ├── mir_heartbeat.c
+│   │   ├── mir_handlers.c # command/config routing
+│   │   ├── mir_schema.c   # sends schema bytes on connect
+│   │   └── mir_store.c    # offline buffering
+│   ├── transport/
+│   │   ├── mir_transport.h        # transport interface
+│   │   ├── mir_nats_core.c        # shared subject/header logic
+│   │   └── mir_nats_msg.c
+│   └── platform/
+│       ├── linux/
+│       │   ├── mir_hal_linux.c    # sockets, file store
+│       │   └── mir_nats_linux.c   # wraps nats.c
+│       └── esp32/
+│           ├── mir_hal_esp32.c    # esp_tls, SPIFFS
+│           └── mir_nats_esp32.c   # custom minimal NATS client
+├── tools/
+│   └── schema_embed/
+│       └── schema_embed.py        # .bin → .h byte array
+├── examples/
+│   ├── linux/main.c
+│   └── esp32/main.c
+├── bindings/
+│   └── python/
+│       └── mir_device.py          # ctypes wrapper
+├── proto/
+│   └── mir/device/v1/mir.proto    # git submodule from mir.server
+├── CMakeLists.txt
+├── library.json                   # PlatformIO
+└── README.md
+```
+
+---
+
+## Python Bindings
+
+Implemented as a pure-Python `ctypes` wrapper around the compiled Linux `.so`. No compilation required by the Python user.
+
+```python
+# bindings/python/mir_device.py
+import ctypes, os
+
+_lib = ctypes.CDLL(os.path.join(os.path.dirname(__file__), "libmir_device.so"))
+
+class MirDevice:
+    def __init__(self, device_id, target, credentials=None):
+        # wraps mir_device_create / mir_device_launch / etc.
+        ...
+
+    def send_telemetry(self, msg_name: str, proto_bytes: bytes): ...
+    def handle_command(self, msg_name: str, fn): ...
+```
+
+Python bindings are deferred to after the C core is working — they are a thin layer with no logic of their own.
+
+---
+
+## Error Handling
+
+All public API functions return `int`:
+- `0` — success
+- `MIR_ERR_INVALID_ARG` (-1)
+- `MIR_ERR_NOT_CONNECTED` (-2)
+- `MIR_ERR_TIMEOUT` (-3)
+- `MIR_ERR_NO_MEMORY` (-4)
+- `MIR_ERR_TRANSPORT` (-5)
+- `MIR_ERR_STORE` (-6)
+
+No exceptions, no `errno` side-effects. Errors are loggable via an optional `mir_log_fn` callback set in config.
+
+---
+
+## Learning Path (C Concepts by Layer)
+
+| Build order | Layer | C concepts covered |
+|---|---|---|
+| 1 | HAL + types | structs, function pointers, `void *` context, header guards |
+| 2 | Transport (Linux) | TCP sockets, `read`/`write`, string parsing, buffers |
+| 3 | Core | `malloc`/`free`, opaque pointers, error codes, threading basics |
+| 4 | Schema gen tool | Python `subprocess`, file I/O (not C) |
+| 5 | ESP32 HAL | FreeRTOS tasks, `esp_tls`, flash filesystem |
+| 6 | Build system | CMake, linking, shared vs static libraries |
+| 7 | Python bindings | `ctypes`, ABI, shared library loading |
+
+Each layer builds on the previous. Start with HAL + Linux transport — you get a working device on Linux before touching MCU complexity.

--- a/docs/superpowers/specs/2026-03-31-cmd-widget-design.md
+++ b/docs/superpowers/specs/2026-03-31-cmd-widget-design.md
@@ -1,0 +1,137 @@
+# Command Widget Design
+
+**Date:** 2026-03-31
+**Branch:** cockpit/cmd_widget
+**Status:** Approved
+
+## Overview
+
+Full rewrite of `widget-command.svelte` to match the feature quality of `widget-telemetry.svelte`. The widget targets N devices via `config.target`, loads their commands in parallel, presents them in a grouped left panel, and provides a JSON editor + inline response log on the right.
+
+## Layout
+
+```
+┌──────────┬────────────────────────────────────┐
+│ Commands │  command-name  [VIM] [COPY] [⛶]    │
+│ (grouped)│  ┌──────────────────────────────┐  │
+│          │  │  JSON editor (CodeMirror)    │  │
+│  cmd-a   │  │                              │  │
+│  cmd-b ◀ │  └──────────────────────────────┘  │
+│  cmd-c   │  [Send] [Dry Run]                   │
+│          │  ─────── responses ──────────────   │
+│          │  ✓ device-1   42ms   {"ok":true}    │
+│          │  ✗ device-2  timeout  error msg     │
+└──────────┴────────────────────────────────────┘
+```
+
+- Left: `DescriptorPanel` in grouped mode
+- Right: `JsonPayloadEditor` (top, flex-1) + response log (bottom, appears after first send)
+- Device pills in the widget wrapper header via `onDevicesReady` callback
+- Fullscreen: `fixed inset-0 z-50 bg-background`, toggled by button or Escape key
+
+## Architecture
+
+### Data Flow
+
+1. On mount (when `mirStore.mir` is ready), call `listCommands()` in parallel for all resolved device IDs
+2. Results are `CommandGroup[]` — each group has `ids[]` (devices sharing that schema) and `descriptors[]`
+3. Feed groups to `DescriptorPanel` in grouped mode; label = comma-joined device names
+4. Call `onDevicesReady` with flat `{id, name}[]` from all groups
+5. User selects a command → set `selectedCommand` + `selectedGroupIdx`
+6. Seed `JsonPayloadEditor` with `selectedCommand.template` JSON
+7. On send → fan out to all devices in the selected group (see Send Flow)
+
+### Config Type Change
+
+`CommandWidgetConfig` in `dashboard-api.ts` gains one optional field:
+
+```ts
+export interface CommandWidgetConfig {
+  target: DeviceTargetConfig;
+  selectedCommand?: string;  // view state: restored after reload
+}
+```
+
+### Component Reuse
+
+No new sub-components. Everything reuses existing pieces:
+
+| Component | Usage |
+|-----------|-------|
+| `DescriptorPanel` | Left panel, grouped mode (`groups`, `onSelectGrouped`, `selectedKey`) |
+| `JsonPayloadEditor` | Right panel editor; `deviceValues` + `onSendMulti` for per-device mode |
+| `activityStore` | Log every send result (existing pattern) |
+| `WidgetDevicePills` | Populated via `onDevicesReady` in `dashboard-grid.svelte` |
+
+## Multi-device Behavior
+
+### Loading
+
+- Resolve device IDs from `config.target` (ids / namespaces / labels) the same way `widget-telemetry.svelte` resolves `deviceInfos` — via a `listCommands()` call with a `DeviceTarget`
+- The SDK returns `CommandGroup[]` where each group covers devices that share a command schema
+- `onDevicesReady` fires after load with the flat list of all `{id, name}` pairs
+
+### Send Flow
+
+**Broadcast mode** (`onSend` — same payload to all devices in group):
+```
+Promise.allSettled(
+  group.ids.map(id => mir.client().sendCommand().request(target(id), name, text, dryRun))
+)
+```
+
+**Per-device mode** (`onSendMulti` — Map<deviceId, payload>):
+```
+Promise.allSettled(
+  [...payloads.entries()].map(([id, text]) => mir.client().sendCommand().request(target(id), name, text, dryRun))
+)
+```
+
+Both flows:
+- Clear the previous response log before sending
+- Append each result as it settles (success or error)
+- Log each result to `activityStore`
+
+## Response Log
+
+Each entry:
+
+```
+✓ / ✗  device-name   <duration>ms   <truncated JSON or error>
+```
+
+- Icon: green check (success) or red X (error)
+- Device name in monospace
+- Duration in milliseconds
+- Response: truncated to ~80 chars inline; full JSON revealed via `<details>` expand
+- Log is hidden before first send; cleared on each new send
+- Log is scrollable with `max-h` constraint so it doesn't push the editor off screen
+
+## View State
+
+`selectedCommand?: string` is saved to `CommandWidgetConfig` via `dashboardStore.saveWidgetViewState()` whenever the selected command changes (after initial load, using `untrack` pattern from tlm widget to avoid save loops).
+
+On load, after commands resolve, re-select the matching descriptor by name if `config.selectedCommand` is set.
+
+## Fullscreen
+
+Same pattern as `widget-telemetry.svelte`:
+- `let fullscreen = $state(false)`
+- Outer div: `class="{fullscreen ? 'fixed inset-0 z-50 bg-background' : 'flex h-full flex-col'} flex flex-col"`
+- `<svelte:window onkeydown>` → set `fullscreen = false` on Escape
+- Fullscreen toggle button in the right-panel header row (above `JsonPayloadEditor`)
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte` | Full rewrite |
+| `internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts` | Add `selectedCommand?` to `CommandWidgetConfig` |
+| `internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte` | Add `onDevicesReady` prop to `<WidgetCommand>` |
+
+## Out of Scope
+
+- New sub-components (reuse only)
+- Changes to `DescriptorPanel`, `JsonPayloadEditor`, or `activityStore`
+- Authentication / permissions
+- Command history persistence beyond the current session

--- a/internal/externals/mng/dashboards.go
+++ b/internal/externals/mng/dashboards.go
@@ -81,7 +81,7 @@ func (s *surrealMirStore) UpdateDashboard(t mir_v1.ObjectTarget, upd mir_v1.Dash
 	if upd.Meta != nil && upd.Meta.Namespace != nil {
 		obj.Meta.Namespace = *upd.Meta.Namespace
 	}
-	if err := validateObjectMetaForUpdate(s.db, surrealEventTable, t, obj); err != nil {
+	if err := validateObjectMetaForUpdate(s.db, surrealDashboardTable, t, obj); err != nil {
 		return nil, err
 	}
 

--- a/internal/externals/mng/object.go
+++ b/internal/externals/mng/object.go
@@ -45,7 +45,7 @@ func createTargetStatementForObjects(t mir_v1.ObjectTarget) string {
 	if len(t.Names) > 0 {
 		var i []string
 		for _, n := range t.Names {
-			i = append(i, fmt.Sprintf("meta.name CONTAINS \"%s\"", n))
+			i = append(i, fmt.Sprintf("meta.name = \"%s\"", n))
 		}
 		cond = append(cond, "("+strings.Join(i, " OR ")+")")
 	}

--- a/internal/servers/cockpit_srv/dashboard_handler.go
+++ b/internal/servers/cockpit_srv/dashboard_handler.go
@@ -85,7 +85,10 @@ func (s *CockpitServer) dashboardHandler(w http.ResponseWriter, r *http.Request)
 					Namespace *string `json:"namespace"`
 				} `json:"meta,omitempty"`
 				Spec struct {
-					Description string `json:"description"`
+					Description     string                   `json:"description"`
+					Widgets         []mir_v1.DashboardWidget `json:"widgets,omitempty"`
+					RefreshInterval *int                     `json:"refreshInterval,omitempty"`
+					TimeMinutes     *int                     `json:"timeMinutes,omitempty"`
 				} `json:"spec"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -94,7 +97,10 @@ func (s *CockpitServer) dashboardHandler(w http.ResponseWriter, r *http.Request)
 			}
 			upd := mir_v1.DashboardUpdate{
 				Spec: &mir_v1.DashboardUpdateSpec{
-					Description: &req.Spec.Description,
+					Description:     &req.Spec.Description,
+					Widgets:         req.Spec.Widgets,
+					RefreshInterval: req.Spec.RefreshInterval,
+					TimeMinutes:     req.Spec.TimeMinutes,
 				},
 			}
 			if req.Meta != nil {

--- a/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
@@ -22,6 +22,9 @@ export interface TelemetryWidgetConfig {
 export interface CommandWidgetConfig {
 	target: DeviceTargetConfig;
 	selectedCommand?: string;
+	// View state (optional — absent in older saved dashboards, template used as default)
+	savedPayload?: string;               // single/template payload
+	savedPayloads?: Record<string, string>; // per-device: { deviceId: jsonText }
 }
 
 export interface ConfigWidgetConfig {

--- a/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
@@ -21,6 +21,7 @@ export interface TelemetryWidgetConfig {
 
 export interface CommandWidgetConfig {
 	target: DeviceTargetConfig;
+	selectedCommand?: string;
 }
 
 export interface ConfigWidgetConfig {

--- a/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/api/dashboard-api.ts
@@ -99,7 +99,7 @@ export const dashboardApi = {
 	get: (namespace: string, name: string): Promise<Dashboard> =>
 		request<Dashboard>(`${BASE}/${namespace}/${name}`),
 
-	create: (name: string, namespace = 'default', description = ''): Promise<Dashboard> =>
+	create: (name: string, namespace = 'default', description = '', widgets: Widget[] = []): Promise<Dashboard> =>
 		request<Dashboard>(BASE, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -107,14 +107,21 @@ export const dashboardApi = {
 				apiVersion: 'mir/v1alpha',
 				kind: 'dashboard',
 				meta: { name, namespace },
-				spec: { description, widgets: [] }
+				spec: { description, widgets }
 			})
 		}),
 
 	update: (
 		namespace: string,
 		name: string,
-		patch: { name?: string; namespace?: string; description?: string }
+		patch: {
+			name?: string;
+			namespace?: string;
+			description?: string;
+			widgets?: Widget[];
+			refreshInterval?: number;
+			timeMinutes?: number;
+		}
 	): Promise<Dashboard> =>
 		request<Dashboard>(`${BASE}/${namespace}/${name}`, {
 			method: 'PUT',
@@ -128,7 +135,12 @@ export const dashboardApi = {
 							}
 						}
 					: {}),
-				spec: { description: patch.description ?? '' }
+				spec: {
+					description: patch.description ?? '',
+					...(patch.widgets !== undefined ? { widgets: patch.widgets } : {}),
+					...(patch.refreshInterval !== undefined ? { refreshInterval: patch.refreshInterval } : {}),
+					...(patch.timeMinutes !== undefined ? { timeMinutes: patch.timeMinutes } : {})
+				}
 			})
 		}),
 

--- a/internal/ui/web/src/lib/domains/dashboards/components/add-widget-dialog.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/add-widget-dialog.svelte
@@ -17,7 +17,7 @@
 		CommandWidgetConfig,
 		ConfigWidgetConfig
 	} from '../api/dashboard-api';
-	import type { TelemetryGroup } from '@mir/sdk';
+	import type { TelemetryGroup, CommandGroup } from '@mir/sdk';
 	import { DeviceTarget } from '@mir/sdk';
 	import ActivityIcon from '@lucide/svelte/icons/activity';
 	import TerminalIcon from '@lucide/svelte/icons/terminal';
@@ -45,6 +45,9 @@
 			if (editWidget.type === 'telemetry') {
 				const c = editWidget.config as TelemetryWidgetConfig;
 				selectedMeasurement = c.measurement;
+			} else if (editWidget.type === 'command') {
+				const c = editWidget.config as CommandWidgetConfig;
+				selectedCommandName = c.selectedCommand ?? '';
 			} else if (editWidget.type === 'events') {
 				eventLimit = (editWidget.config as EventsWidgetConfig).limit;
 			}
@@ -68,12 +71,23 @@
 	let measurementsLoading = $state(false);
 	let selectedMeasurement = $state('');
 
+	// Command config
+	let commandGroups = $state<CommandGroup[]>([]);
+	let commandsLoading = $state(false);
+	let selectedCommandName = $state('');
+
 	// Events config
 	let eventLimit = $state(50);
 
 	$effect(() => {
 		if (step === 'config' && selectedType === 'telemetry' && mirStore.mir) {
 			loadMeasurements();
+		}
+	});
+
+	$effect(() => {
+		if (step === 'config' && selectedType === 'command' && mirStore.mir) {
+			loadCommandsForWizard();
 		}
 	});
 
@@ -118,6 +132,37 @@
 		}
 	}
 
+	async function loadCommandsForWizard() {
+		commandsLoading = true;
+		commandGroups = [];
+		try {
+			let deviceIds: string[] = [];
+			if (target.ids?.length) {
+				deviceIds = target.ids;
+			} else {
+				deviceIds = deviceStore.devices
+					.filter((d) => {
+						const nsMatch =
+							!target.namespaces?.length ||
+							target.namespaces.includes(d.meta?.namespace ?? 'default');
+						const labelMatch =
+							!target.labels ||
+							Object.entries(target.labels).every(([k, v]) => d.meta?.labels?.[k] === v);
+						return nsMatch && labelMatch;
+					})
+					.map((d) => d.spec?.deviceId)
+					.filter((id): id is string => Boolean(id));
+			}
+			if (!deviceIds.length) return;
+			const deviceTarget = new DeviceTarget({ ids: deviceIds });
+			commandGroups = await mirStore.mir!.client().listCommands().request(deviceTarget);
+		} catch {
+			commandGroups = [];
+		} finally {
+			commandsLoading = false;
+		}
+	}
+
 	function reset() {
 		step = 'type';
 		selectedType = null;
@@ -126,6 +171,9 @@
 		measurementGroups = [];
 		measurementsLoading = false;
 		selectedMeasurement = '';
+		commandGroups = [];
+		commandsLoading = false;
+		selectedCommandName = '';
 		eventLimit = 50;
 		editWidget = null;
 	}
@@ -167,7 +215,7 @@
 				} satisfies TelemetryWidgetConfig;
 			}
 			case 'command':
-				return { target } satisfies CommandWidgetConfig;
+				return { target, selectedCommand: selectedCommandName } satisfies CommandWidgetConfig;
 			case 'config':
 				return { target } satisfies ConfigWidgetConfig;
 			case 'events':
@@ -319,6 +367,53 @@
 								>
 							</div>
 						{/if}
+					{:else if selectedType === 'command'}
+						<div class="space-y-1">
+							<p class="text-sm font-medium">Command</p>
+							{#if commandsLoading}
+								<div class="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+									<Spinner class="h-4 w-4" />
+									<span>Loading commands…</span>
+								</div>
+							{:else if commandGroups.length === 0}
+								<p class="py-2 text-sm text-muted-foreground">
+									No commands found for selected devices.
+								</p>
+							{:else}
+								<div class="max-h-64 space-y-2 overflow-y-auto">
+									{#each commandGroups as group, gi (gi)}
+										<div class="rounded-md border border-border">
+											<div class="flex flex-wrap items-center gap-1 border-b px-3 py-2">
+												{#each group.ids as dev (dev.id)}
+													<Badge variant="secondary" class="font-mono text-xs font-normal"
+														>{dev.name}</Badge
+													>
+												{/each}
+											</div>
+											<div class="divide-y">
+												{#each group.descriptors as cmd (cmd.name)}
+													<button
+														onclick={() => (selectedCommandName = cmd.name)}
+														class="flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-accent
+															{selectedCommandName === cmd.name ? 'bg-muted' : ''}"
+													>
+														<span
+															class="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border
+																{selectedCommandName === cmd.name ? 'border-primary bg-primary' : 'border-muted-foreground'}"
+														>
+															{#if selectedCommandName === cmd.name}
+																<span class="h-1.5 w-1.5 rounded-full bg-primary-foreground"></span>
+															{/if}
+														</span>
+														<span class="flex-1 font-mono">{cmd.name}</span>
+													</button>
+												{/each}
+											</div>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						</div>
 					{:else if selectedType === 'events'}
 						<div class="space-y-1">
 							<label for="widget-maxevents" class="text-sm font-medium">Max events</label>
@@ -326,7 +421,7 @@
 						</div>
 					{:else}
 						<p class="text-sm text-muted-foreground">
-							{editWidget ? typeLabel(selectedType!) + ' widget is ready. Click Save to update.' : typeLabel(selectedType!) + ' widget is ready to add. Select a command or config after adding.'}
+							{editWidget ? typeLabel(selectedType!) + ' widget is ready. Click Save to update.' : typeLabel(selectedType!) + ' widget is ready to add.'}
 						</p>
 					{/if}
 				</div>
@@ -336,7 +431,8 @@
 					<Button
 						onclick={saveWidget}
 						disabled={dashboardStore.isSaving ||
-							(selectedType === 'telemetry' && !selectedMeasurement)}
+							(selectedType === 'telemetry' && !selectedMeasurement) ||
+							(selectedType === 'command' && !selectedCommandName)}
 					>
 						{dashboardStore.isSaving ? (editWidget ? 'Saving…' : 'Adding…') : (editWidget ? 'Save' : 'Add Widget')}
 					</Button>

--- a/internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte
@@ -105,7 +105,11 @@
 							onDevicesReady={(infos) => widgetDevices.set(widget.id, infos)}
 						/>
 					{:else if widget.type === 'command'}
-						<WidgetCommand config={widget.config as CommandWidgetConfig} />
+						<WidgetCommand
+							widgetId={widget.id}
+							config={widget.config as CommandWidgetConfig}
+							onDevicesReady={(infos) => widgetDevices.set(widget.id, infos)}
+						/>
 					{:else if widget.type === 'config'}
 						<WidgetConfig config={widget.config as ConfigWidgetConfig} />
 					{:else if widget.type === 'events'}

--- a/internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/dashboard-grid.svelte
@@ -35,6 +35,7 @@
 
 		grid.on('change', () => {
 			if (!dashboardStore.activeDashboard || !grid) return;
+			if (!dashboardStore.editMode && !dashboardStore.isCreatingNew) return;
 			const items = grid.save(false) as import('gridstack').GridStackWidget[];
 			const layout = items.map((item) => ({
 				id: item.id as string,

--- a/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
@@ -340,10 +340,6 @@
 				{/snippet}
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content align="end">
-				<DropdownMenu.Item onclick={createDashboard}>
-					<PlusIcon class="mr-2 size-3.5" />
-					New Dashboard
-				</DropdownMenu.Item>
 				{#if dashboardStore.activeDashboard}
 					<DropdownMenu.Item
 						onclick={() => {
@@ -356,6 +352,10 @@
 						Edit Dashboard
 					</DropdownMenu.Item>
 				{/if}
+				<DropdownMenu.Item onclick={createDashboard}>
+					<PlusIcon class="mr-2 size-3.5" />
+					New Dashboard
+				</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	{/if}

--- a/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { dashboardStore } from '../stores/dashboard.svelte';
 	import { dashboardKey } from '../api/dashboard-api';
 	import { Button } from '$lib/shared/components/shadcn/button';
@@ -125,17 +126,24 @@
 			}
 			return;
 		}
-		if (dashboardStore.activeDashboard) {
-			try {
-				await dashboardStore.update(dashboardStore.activeDashboard, {
-					name: renameName.trim(),
-					namespace: renameNamespace.trim() || 'default'
-				});
-			} catch {
-				return; // error reported via activityStore
+		const d = dashboardStore.activeDashboard;
+		if (d) {
+			const nameChanged = renameName.trim() !== d.meta.name;
+			const nsChanged = (renameNamespace.trim() || 'default') !== d.meta.namespace;
+			if (nameChanged || nsChanged) {
+				try {
+					await dashboardStore.update(d, {
+						name: renameName.trim(),
+						namespace: renameNamespace.trim() || 'default'
+					});
+				} catch {
+					return; // error reported via activityStore
+				}
 			}
 		}
-		dashboardStore.saveEditMode();
+		dashboardStore.saveEditMode(); // cancels all pending timers, sets editMode = false
+		await tick(); // let widget effects update activeDashboard in-memory
+		await dashboardStore.persistActiveDashboard(); // single persist
 	}
 
 	async function cancelEdits() {

--- a/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/dashboard-toolbar.svelte
@@ -56,7 +56,7 @@
 	$effect(() => {
 		const interval = editorPrefs.refreshInterval;
 		const d = dashboardStore.activeDashboard;
-		if (!d) return;
+		if (!d || !dashboardStore.editMode) return;
 		if ((d.spec.refreshInterval ?? 10) === interval) return;
 		dashboardStore.saveRefreshInterval(d, interval);
 	});
@@ -64,7 +64,7 @@
 	$effect(() => {
 		const minutes = editorPrefs.timeMinutes;
 		const d = dashboardStore.activeDashboard;
-		if (!d) return;
+		if (!d || !dashboardStore.editMode) return;
 		if ((d.spec.timeMinutes ?? 60) === minutes) return;
 		dashboardStore.saveTimeMinutes(d, minutes);
 	});
@@ -127,23 +127,30 @@
 			return;
 		}
 		const d = dashboardStore.activeDashboard;
-		if (d) {
-			const nameChanged = renameName.trim() !== d.meta.name;
-			const nsChanged = (renameNamespace.trim() || 'default') !== d.meta.namespace;
-			if (nameChanged || nsChanged) {
-				try {
-					await dashboardStore.update(d, {
-						name: renameName.trim(),
-						namespace: renameNamespace.trim() || 'default'
-					});
-				} catch {
-					return; // error reported via activityStore
-				}
-			}
+		if (!d) return;
+
+		const nameChanged = renameName.trim() !== d.meta.name;
+		const nsChanged = (renameNamespace.trim() || 'default') !== d.meta.namespace;
+
+		// Exit edit mode FIRST so widget dirty effects (e.g. command payload save) run
+		// before any name change triggers a {#key} remount and destroys the widgets.
+		dashboardStore.saveEditMode();
+		await tick();
+
+		// After tick, activeDashboard has the latest widget state (dirty effects have flushed).
+		// Send everything in a single PUT — meta rename + widgets + time settings.
+		const snap = dashboardStore.activeDashboard?.spec;
+		try {
+			await dashboardStore.update(d, {
+				...(nameChanged ? { name: renameName.trim() } : {}),
+				...(nsChanged ? { namespace: renameNamespace.trim() || 'default' } : {}),
+				widgets: snap?.widgets ?? d.spec.widgets,
+				refreshInterval: snap?.refreshInterval,
+				timeMinutes: snap?.timeMinutes
+			});
+		} catch {
+			// error reported via activityStore
 		}
-		dashboardStore.saveEditMode(); // cancels all pending timers, sets editMode = false
-		await tick(); // let widget effects update activeDashboard in-memory
-		await dashboardStore.persistActiveDashboard(); // single persist
 	}
 
 	async function cancelEdits() {
@@ -303,8 +310,8 @@
 			<DeleteButton
 				confirmValue="{dashboardStore.activeDashboard.meta.namespace}/{dashboardStore
 					.activeDashboard.meta.name}"
-				confirmHint="Type &quot;{dashboardStore.activeDashboard.meta.name}/{dashboardStore
-					.activeDashboard.meta.namespace}&quot; to confirm."
+				confirmHint="Type &quot;{dashboardStore.activeDashboard.meta.namespace}/{dashboardStore
+					.activeDashboard.meta.name}&quot; to confirm."
 				error={deleteError}
 				{isDeleting}
 				onconfirm={removeDashboard}
@@ -350,8 +357,8 @@
 			<DropdownMenu.Content align="end">
 				{#if dashboardStore.activeDashboard}
 					<DropdownMenu.Item
-						onclick={() => {
-							const { name, namespace } = dashboardStore.enterEditMode();
+						onclick={async () => {
+							const { name, namespace } = await dashboardStore.enterEditMode();
 							renameName = name;
 							renameNamespace = namespace;
 						}}

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -1,55 +1,151 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { mirStore } from '$lib/domains/mir/stores/mir.svelte';
-	import {
-		DescriptorPanel,
-		JsonPayloadEditor
-	} from '$lib/domains/devices/components/commands';
+	import { DescriptorPanel, JsonPayloadEditor } from '$lib/domains/devices/components/commands';
 	import { DeviceTarget } from '@mir/sdk';
 	import type { CommandDescriptor, CommandGroup } from '@mir/sdk';
+	import { CommandResponseStatus } from '@mir/sdk';
 	import { activityStore } from '$lib/domains/activity/stores/activity.svelte';
+	import { dashboardStore } from '$lib/domains/dashboards/stores/dashboard.svelte';
+	import { CHART_COLORS } from '$lib/domains/devices/utils/tlm-time';
 	import type { CommandWidgetConfig } from '../api/dashboard-api';
+	import MaximizeIcon from '@lucide/svelte/icons/maximize';
+	import MinimizeIcon from '@lucide/svelte/icons/minimize';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import XCircleIcon from '@lucide/svelte/icons/x-circle';
 
-	let { config }: { config: CommandWidgetConfig } = $props();
+	let {
+		config,
+		widgetId,
+		onDevicesReady
+	}: {
+		config: CommandWidgetConfig;
+		widgetId: string;
+		onDevicesReady?: (infos: { id: string; name: string; color: string }[]) => void;
+	} = $props();
 
-	const deviceId = $derived((config.target.ids ?? [])[0] ?? '');
+	// ─── Types ────────────────────────────────────────────────────────────────
 
-	// Local state (not a singleton)
-	let commands = $state<CommandGroup[]>([]);
+	type CmdResponseEntry = {
+		deviceId: string;
+		deviceName: string;
+		status: 'success' | 'error';
+		message: string;
+		durationMs: number;
+		expanded: boolean;
+	};
+
+	// ─── State ────────────────────────────────────────────────────────────────
+
+	let groups = $state<CommandGroup[]>([]);
 	let isLoading = $state(false);
-	let error = $state<string | null>(null);
-	let isSending = $state(false);
-	let sendError = $state<string | null>(null);
+	let loadError = $state<string | null>(null);
+	let hasLoaded = $state(false);
+
+	let selectedGroupIdx = $state<number | null>(null);
 	let selectedCommand = $state<CommandDescriptor | null>(null);
 	let editorContent = $state('{}');
 
-	let allDescriptors = $derived(commands.flatMap((g) => g.descriptors));
-	let groupErrors = $derived(commands.map((g) => g.error).filter(Boolean) as string[]);
+	let isSending = $state(false);
+	let sendError = $state<string | null>(null);
+	let responses = $state<CmdResponseEntry[]>([]);
+	let hasResponses = $state(false);
 
-	async function loadCommands() {
-		const mir = mirStore.mir;
-		if (!mir || !deviceId) return;
-		isLoading = true;
-		error = null;
-		try {
-			const target = new DeviceTarget({ ids: [deviceId] });
-			commands = await mir.client().listCommands().request(target);
-		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to load commands';
-		} finally {
-			isLoading = false;
-		}
-	}
+	let fullscreen = $state(false);
+
+	// ─── Derived ──────────────────────────────────────────────────────────────
+
+	const selectedKey = $derived(
+		selectedGroupIdx !== null && selectedCommand
+			? `${selectedGroupIdx}:${selectedCommand.name}`
+			: null
+	);
+
+	const descriptorGroups = $derived(
+		groups.map((g) => ({
+			label: g.ids.map((d) => `${d.name}/${d.namespace}`).join(', '),
+			items: g.descriptors,
+			errors: g.error ? [g.error] : []
+		}))
+	);
+
+	const groupErrors = $derived(groups.map((g) => g.error).filter(Boolean) as string[]);
+
+	const selectedGroupDevices = $derived(
+		selectedGroupIdx !== null ? (groups[selectedGroupIdx]?.ids ?? []) : []
+	);
+
+	const deviceValues = $derived.by(() => {
+		if (selectedGroupDevices.length <= 1) return undefined;
+		return selectedGroupDevices.map((d) => ({
+			label: `${d.name}/${d.namespace}`,
+			deviceId: d.id,
+			values: editorContent
+		}));
+	});
+
+	// ─── Startup ──────────────────────────────────────────────────────────────
 
 	$effect(() => {
-		if (mirStore.mir && deviceId) {
-			selectedCommand = null;
-			editorContent = '{}';
-			commands = [];
-			loadCommands();
+		if (mirStore.mir) {
+			untrack(loadCommands);
+		} else {
+			groups = [];
+			loadError = null;
 		}
 	});
 
-	function selectCommand(desc: CommandDescriptor) {
+	async function loadCommands() {
+		const mir = mirStore.mir;
+		if (!mir) return;
+
+		isLoading = true;
+		loadError = null;
+		groups = [];
+		selectedCommand = null;
+		selectedGroupIdx = null;
+		responses = [];
+		hasResponses = false;
+
+		try {
+			const target = new DeviceTarget({
+				ids: config.target.ids,
+				namespaces: config.target.namespaces,
+				labels: config.target.labels
+			});
+			groups = await mir.client().listCommands().request(target);
+
+			const allDevices = groups.flatMap((g) => g.ids);
+			onDevicesReady?.(
+				allDevices.map((d, i) => ({
+					id: d.id,
+					name: d.name,
+					color: CHART_COLORS[i % CHART_COLORS.length]
+				}))
+			);
+
+			// Restore selected command from view state
+			if (config.selectedCommand) {
+				for (let gi = 0; gi < groups.length; gi++) {
+					const desc = groups[gi].descriptors.find((d) => d.name === config.selectedCommand);
+					if (desc) {
+						selectCommand(gi, desc);
+						break;
+					}
+				}
+			}
+		} catch (err) {
+			loadError = err instanceof Error ? err.message : 'Failed to load commands';
+		} finally {
+			isLoading = false;
+			hasLoaded = true;
+		}
+	}
+
+	// ─── Selection ────────────────────────────────────────────────────────────
+
+	function selectCommand(groupIdx: number, desc: CommandDescriptor) {
+		selectedGroupIdx = groupIdx;
 		selectedCommand = desc;
 		try {
 			editorContent = JSON.stringify(JSON.parse(desc.template || '{}'), null, 2);
@@ -58,64 +154,246 @@
 		}
 		isSending = false;
 		sendError = null;
+		responses = [];
+		hasResponses = false;
 	}
 
-	async function handleSend(dryRun: boolean, text: string) {
-		const mir = mirStore.mir;
-		if (!mir || !selectedCommand) return;
-		isSending = true;
-		sendError = null;
+	// ─── View state ───────────────────────────────────────────────────────────
+
+	$effect(() => {
+		if (!hasLoaded) return;
+		const name = selectedCommand?.name;
+		untrack(() => {
+			dashboardStore.saveWidgetViewState(widgetId, {
+				...config,
+				selectedCommand: name
+			});
+		});
+	});
+
+	// ─── Send helpers ─────────────────────────────────────────────────────────
+
+	function isResponseSuccess(status: CommandResponseStatus): boolean {
+		return status === CommandResponseStatus.SUCCESS || status === CommandResponseStatus.VALIDATED;
+	}
+
+	function responseMessage(status: CommandResponseStatus, error: string): string {
+		if (error) return error;
+		return CommandResponseStatus[status] ?? 'OK';
+	}
+
+	async function sendToDevice(
+		mir: NonNullable<typeof mirStore.mir>,
+		deviceId: string,
+		deviceName: string,
+		text: string,
+		dryRun: boolean
+	): Promise<CmdResponseEntry> {
+		const start = performance.now();
 		try {
 			const target = new DeviceTarget({ ids: [deviceId] });
 			const result = await mir
 				.client()
 				.sendCommand()
-				.request(target, selectedCommand.name, text, dryRun);
+				.request(target, selectedCommand!.name, text, dryRun);
+			const durationMs = Math.round(performance.now() - start);
+			const resp = result.get(deviceId) ?? [...result.values()][0];
+			const success = resp ? isResponseSuccess(resp.status) : true;
+			const message = resp ? responseMessage(resp.status, resp.error) : 'OK';
 			activityStore.add({
-				kind: 'success',
+				kind: success ? 'success' : 'error',
 				category: 'Command',
-				title: selectedCommand.name,
-				request: { deviceId, name: selectedCommand.name, text, dryRun },
-				response: Object.fromEntries(result)
+				title: selectedCommand!.name,
+				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				...(success ? { response: Object.fromEntries(result) } : { error: message })
 			});
+			return { deviceId, deviceName, status: success ? 'success' : 'error', message, durationMs, expanded: false };
 		} catch (err) {
-			sendError = err instanceof Error ? err.message : 'Failed to send command';
+			const durationMs = Math.round(performance.now() - start);
+			const message = err instanceof Error ? err.message : 'Failed';
 			activityStore.add({
 				kind: 'error',
 				category: 'Command',
-				title: selectedCommand.name,
-				request: { deviceId, name: selectedCommand.name, text, dryRun },
-				error: sendError
+				title: selectedCommand!.name,
+				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				error: message
 			});
-		} finally {
-			isSending = false;
+			return { deviceId, deviceName, status: 'error', message, durationMs, expanded: false };
 		}
+	}
+
+	// ─── Send (broadcast) ─────────────────────────────────────────────────────
+
+	async function handleSend(dryRun: boolean, text: string) {
+		const mir = mirStore.mir;
+		if (!mir || !selectedCommand || selectedGroupDevices.length === 0) return;
+
+		isSending = true;
+		sendError = null;
+		responses = [];
+		hasResponses = true;
+
+		const results = await Promise.allSettled(
+			selectedGroupDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
+		);
+
+		responses = results.map((r) =>
+			r.status === 'fulfilled'
+				? r.value
+				: {
+						deviceId: '',
+						deviceName: 'unknown',
+						status: 'error' as const,
+						message: String(r.reason),
+						durationMs: 0,
+						expanded: false
+					}
+		);
+
+		isSending = false;
+	}
+
+	// ─── Send (per-device) ────────────────────────────────────────────────────
+
+	async function handleSendMulti(dryRun: boolean, payloads: Map<string, string>) {
+		const mir = mirStore.mir;
+		if (!mir || !selectedCommand) return;
+
+		isSending = true;
+		sendError = null;
+		responses = [];
+		hasResponses = true;
+
+		const results = await Promise.allSettled(
+			[...payloads.entries()].map(([deviceId, text]) => {
+				const dev =
+					selectedGroupDevices.find((d) => d.id === deviceId) ??
+					({ id: deviceId, name: deviceId, namespace: 'default' } as const);
+				return sendToDevice(mir, dev.id, dev.name, text, dryRun);
+			})
+		);
+
+		responses = results.map((r) =>
+			r.status === 'fulfilled'
+				? r.value
+				: {
+						deviceId: '',
+						deviceName: 'unknown',
+						status: 'error' as const,
+						message: String(r.reason),
+						durationMs: 0,
+						expanded: false
+					}
+		);
+
+		isSending = false;
 	}
 </script>
 
-<div class="flex h-full overflow-hidden">
-	<DescriptorPanel
-		title="Commands"
-		items={allDescriptors}
-		{isLoading}
-		{error}
-		{groupErrors}
-		selectedName={selectedCommand?.name ?? null}
-		emptyText="No commands."
-		onSelect={selectCommand}
-	/>
-	<div class="min-w-0 flex-1 overflow-auto">
-		{#if selectedCommand}
-			<JsonPayloadEditor
-				name={selectedCommand.name}
-				value={editorContent}
-				hasResponse={false}
-				{isSending}
-				{sendError}
-				onSend={handleSend}
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape' && fullscreen) fullscreen = false;
+	}}
+/>
+
+<div
+	class="{fullscreen
+		? 'fixed inset-0 z-50 bg-background'
+		: 'h-full'} flex flex-col overflow-hidden"
+>
+	{#if loadError}
+		<p class="px-4 py-2 text-xs text-destructive">{loadError}</p>
+	{:else}
+		<div class="flex min-h-0 flex-1 overflow-hidden">
+			<!-- Left: command list -->
+			<DescriptorPanel
+				title="Commands"
+				items={[]}
+				{isLoading}
+				error={null}
+				{groupErrors}
+				groups={descriptorGroups}
+				onSelect={() => {}}
+				onSelectGrouped={(gi, desc) => selectCommand(gi, desc)}
+				selectedKey={selectedKey}
+				emptyText="No commands."
 			/>
-		{:else}
-			<p class="text-muted-foreground p-4 text-xs">Select a command</p>
-		{/if}
-	</div>
+
+			<!-- Right: editor + responses -->
+			<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+				{#if selectedCommand}
+					<!-- Fullscreen toggle -->
+					<div class="flex shrink-0 items-center justify-end px-2 py-0.5">
+						<button
+							onclick={() => (fullscreen = !fullscreen)}
+							title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+							class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+						>
+							{#if fullscreen}
+								<MinimizeIcon class="size-3.5" />
+							{:else}
+								<MaximizeIcon class="size-3.5" />
+							{/if}
+						</button>
+					</div>
+
+					<!-- JSON editor -->
+					<div class="flex min-h-0 flex-1 overflow-hidden">
+						<JsonPayloadEditor
+							name={selectedCommand.name}
+							value={editorContent}
+							hasResponse={false}
+							{isSending}
+							{sendError}
+							{deviceValues}
+							onSend={handleSend}
+							onSendMulti={handleSendMulti}
+						/>
+					</div>
+
+					<!-- Response log (appears after first send) -->
+					{#if hasResponses}
+						<div class="max-h-48 shrink-0 overflow-y-auto border-t">
+							<div class="border-b px-3 py-1">
+								<span
+									class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+									>Responses</span
+								>
+							</div>
+							{#each responses as entry (entry.deviceId + entry.deviceName)}
+								<div class="border-b last:border-0">
+									<button
+										class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/50"
+										onclick={() => (entry.expanded = !entry.expanded)}
+									>
+										{#if entry.status === 'success'}
+											<CheckIcon class="size-3 shrink-0 text-emerald-500" />
+										{:else}
+											<XCircleIcon class="size-3 shrink-0 text-destructive" />
+										{/if}
+										<span class="min-w-0 flex-1 truncate font-mono text-xs"
+											>{entry.deviceName}</span
+										>
+										<span class="shrink-0 font-mono text-[10px] text-muted-foreground"
+											>{entry.durationMs}ms</span
+										>
+										<span
+											class="max-w-32 truncate font-mono text-[10px] text-muted-foreground"
+											>{entry.message}</span
+										>
+									</button>
+									{#if entry.expanded}
+										<pre
+											class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.message}</pre>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+				{:else}
+					<p class="p-4 text-xs text-muted-foreground">Select a command</p>
+				{/if}
+			</div>
+		</div>
+	{/if}
 </div>

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { mirStore } from '$lib/domains/mir/stores/mir.svelte';
-	import { DescriptorPanel, JsonPayloadEditor } from '$lib/domains/devices/components/commands';
+	import { JsonPayloadEditor } from '$lib/domains/devices/components/commands';
 	import { DeviceTarget } from '@mir/sdk';
 	import type { CommandDescriptor, CommandGroup } from '@mir/sdk';
 	import { CommandResponseStatus } from '@mir/sdk';
 	import { activityStore } from '$lib/domains/activity/stores/activity.svelte';
-	import { dashboardStore } from '$lib/domains/dashboards/stores/dashboard.svelte';
 	import { CHART_COLORS } from '$lib/domains/devices/utils/tlm-time';
 	import type { CommandWidgetConfig } from '../api/dashboard-api';
 	import MaximizeIcon from '@lucide/svelte/icons/maximize';
@@ -16,7 +15,7 @@
 
 	let {
 		config,
-		widgetId,
+		widgetId: _widgetId,
 		onDevicesReady
 	}: {
 		config: CommandWidgetConfig;
@@ -38,13 +37,12 @@
 
 	// ─── State ────────────────────────────────────────────────────────────────
 
-	let groups = $state<CommandGroup[]>([]);
 	let isLoading = $state(false);
 	let loadError = $state<string | null>(null);
 	let hasLoaded = $state(false);
 
-	let selectedGroupIdx = $state<number | null>(null);
-	let selectedCommand = $state<CommandDescriptor | null>(null);
+	let activeDescriptor = $state<CommandDescriptor | null>(null);
+	let activeDevices = $state<{ id: string; name: string; namespace: string }[]>([]);
 	let editorContent = $state('{}');
 
 	let isSending = $state(false);
@@ -56,38 +54,16 @@
 
 	// ─── Derived ──────────────────────────────────────────────────────────────
 
-	const selectedKey = $derived(
-		selectedGroupIdx !== null && selectedCommand
-			? `${selectedGroupIdx}:${selectedCommand.name}`
-			: null
-	);
-
-	const descriptorGroups = $derived(
-		groups.map((g) => ({
-			label: g.ids.map((d) => `${d.name}/${d.namespace}`).join(', '),
-			items: g.descriptors,
-			errors: g.error ? [g.error] : []
-		}))
-	);
-
-	const groupErrors = $derived(groups.map((g) => g.error).filter(Boolean) as string[]);
-
-	const selectedGroupDevices = $derived(
-		selectedGroupIdx !== null ? (groups[selectedGroupIdx]?.ids ?? []) : []
-	);
-
 	const deviceValues = $derived.by(() => {
-		if (selectedGroupDevices.length <= 1) return undefined;
-		return selectedGroupDevices.map((d) => ({
+		if (activeDevices.length <= 1) return undefined;
+		return activeDevices.map((d) => ({
 			label: `${d.name}/${d.namespace}`,
 			deviceId: d.id,
 			values: editorContent
 		}));
 	});
 
-	const configKey = $derived(
-		JSON.stringify(config.target ?? {})
-	);
+	const configKey = $derived(JSON.stringify(config.target ?? {}));
 
 	// ─── Startup ──────────────────────────────────────────────────────────────
 
@@ -95,7 +71,8 @@
 		if (mirStore.mir) {
 			untrack(loadCommands);
 		} else {
-			groups = [];
+			activeDescriptor = null;
+			activeDevices = [];
 			loadError = null;
 		}
 	});
@@ -110,13 +87,10 @@
 
 	async function loadCommands() {
 		const mir = mirStore.mir;
-		if (!mir) return;
+		if (!mir || !config.selectedCommand) return;
 
 		isLoading = true;
 		loadError = null;
-		groups = [];
-		selectedCommand = null;
-		selectedGroupIdx = null;
 		responses = [];
 		hasResponses = false;
 
@@ -126,7 +100,30 @@
 				namespaces: config.target.namespaces,
 				labels: config.target.labels
 			});
-			groups = await mir.client().listCommands().request(target);
+			const groups: CommandGroup[] = await mir.client().listCommands().request(target);
+
+			// Find the group + descriptor for the configured command
+			let found: { group: CommandGroup; desc: CommandDescriptor } | null = null;
+			for (const g of groups) {
+				const desc = g.descriptors.find((d) => d.name === config.selectedCommand);
+				if (desc) {
+					found = { group: g, desc };
+					break;
+				}
+			}
+
+			if (!found) {
+				loadError = `Command "${config.selectedCommand}" not found on target devices`;
+				return;
+			}
+
+			activeDescriptor = found.desc;
+			activeDevices = found.group.ids;
+			try {
+				editorContent = JSON.stringify(JSON.parse(found.desc.template || '{}'), null, 2);
+			} catch {
+				editorContent = found.desc.template || '{}';
+			}
 
 			const allDevices = groups.flatMap((g) => g.ids);
 			onDevicesReady?.(
@@ -137,16 +134,6 @@
 				}))
 			);
 
-			// Restore selected command from view state
-			if (config.selectedCommand) {
-				for (let gi = 0; gi < groups.length; gi++) {
-					const desc = groups[gi].descriptors.find((d) => d.name === config.selectedCommand);
-					if (desc) {
-						selectCommand(gi, desc);
-						break;
-					}
-				}
-			}
 			hasLoaded = true;
 		} catch (err) {
 			loadError = err instanceof Error ? err.message : 'Failed to load commands';
@@ -154,35 +141,6 @@
 			isLoading = false;
 		}
 	}
-
-	// ─── Selection ────────────────────────────────────────────────────────────
-
-	function selectCommand(groupIdx: number, desc: CommandDescriptor) {
-		selectedGroupIdx = groupIdx;
-		selectedCommand = desc;
-		try {
-			editorContent = JSON.stringify(JSON.parse(desc.template || '{}'), null, 2);
-		} catch {
-			editorContent = desc.template || '{}';
-		}
-		isSending = false;
-		sendError = null;
-		responses = [];
-		hasResponses = false;
-	}
-
-	// ─── View state ───────────────────────────────────────────────────────────
-
-	$effect(() => {
-		if (!hasLoaded) return;
-		const name = selectedCommand?.name;
-		untrack(() => {
-			dashboardStore.saveWidgetViewState(widgetId, {
-				...config,
-				selectedCommand: name
-			});
-		});
-	});
 
 	// ─── Send helpers ─────────────────────────────────────────────────────────
 
@@ -208,7 +166,7 @@
 			const result = await mir
 				.client()
 				.sendCommand()
-				.request(target, selectedCommand!.name, text, dryRun);
+				.request(target, activeDescriptor!.name, text, dryRun);
 			const durationMs = Math.round(performance.now() - start);
 			const resp = result.get(deviceId) ?? [...result.values()][0];
 			const success = resp ? isResponseSuccess(resp.status) : true;
@@ -216,8 +174,8 @@
 			activityStore.add({
 				kind: success ? 'success' : 'error',
 				category: 'Command',
-				title: selectedCommand!.name,
-				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				title: activeDescriptor!.name,
+				request: { deviceId, name: activeDescriptor!.name, text, dryRun },
 				...(success ? { response: Object.fromEntries(result) } : { error: message })
 			});
 			return { deviceId, deviceName, status: success ? 'success' : 'error', message, durationMs, expanded: false };
@@ -227,8 +185,8 @@
 			activityStore.add({
 				kind: 'error',
 				category: 'Command',
-				title: selectedCommand!.name,
-				request: { deviceId, name: selectedCommand!.name, text, dryRun },
+				title: activeDescriptor!.name,
+				request: { deviceId, name: activeDescriptor!.name, text, dryRun },
 				error: message
 			});
 			return { deviceId, deviceName, status: 'error', message, durationMs, expanded: false };
@@ -239,7 +197,7 @@
 
 	async function handleSend(dryRun: boolean, text: string) {
 		const mir = mirStore.mir;
-		if (!mir || !selectedCommand || selectedGroupDevices.length === 0) return;
+		if (!mir || !activeDescriptor || activeDevices.length === 0) return;
 
 		isSending = true;
 		sendError = null;
@@ -248,21 +206,12 @@
 
 		try {
 			const results = await Promise.allSettled(
-				selectedGroupDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
+				activeDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
 			);
-
 			responses = results.map((r, i) =>
 				r.status === 'fulfilled'
 					? { ...r.value, idx: i }
-					: {
-							idx: i,
-							deviceId: '',
-							deviceName: 'unknown',
-							status: 'error' as const,
-							message: String(r.reason),
-							durationMs: 0,
-							expanded: false
-						}
+					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), durationMs: 0, expanded: false }
 			);
 		} catch (err) {
 			sendError = err instanceof Error ? err.message : 'Send failed';
@@ -276,7 +225,7 @@
 
 	async function handleSendMulti(dryRun: boolean, payloads: Map<string, string>) {
 		const mir = mirStore.mir;
-		if (!mir || !selectedCommand) return;
+		if (!mir || !activeDescriptor) return;
 
 		isSending = true;
 		sendError = null;
@@ -287,24 +236,15 @@
 			const results = await Promise.allSettled(
 				[...payloads.entries()].map(([deviceId, text]) => {
 					const dev =
-						selectedGroupDevices.find((d) => d.id === deviceId) ??
+						activeDevices.find((d) => d.id === deviceId) ??
 						({ id: deviceId, name: deviceId, namespace: 'default' } as const);
 					return sendToDevice(mir, dev.id, dev.name, text, dryRun);
 				})
 			);
-
 			responses = results.map((r, i) =>
 				r.status === 'fulfilled'
 					? { ...r.value, idx: i }
-					: {
-							idx: i,
-							deviceId: '',
-							deviceName: 'unknown',
-							status: 'error' as const,
-							message: String(r.reason),
-							durationMs: 0,
-							expanded: false
-						}
+					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), durationMs: 0, expanded: false }
 			);
 		} catch (err) {
 			sendError = err instanceof Error ? err.message : 'Send failed';
@@ -326,99 +266,78 @@
 		? 'fixed inset-0 z-50 bg-background'
 		: 'h-full'} flex flex-col overflow-hidden"
 >
-	{#if loadError}
-		<p class="px-4 py-2 text-xs text-destructive">{loadError}</p>
-	{:else}
-		<div class="flex min-h-0 flex-1 overflow-hidden">
-			<!-- Left: command list -->
-			<DescriptorPanel
-				title="Commands"
-				items={[]}
-				{isLoading}
-				error={null}
-				{groupErrors}
-				groups={descriptorGroups}
-				onSelect={() => {}}
-				onSelectGrouped={(gi, desc) => selectCommand(gi, desc)}
-				selectedKey={selectedKey}
-				emptyText="No commands."
-			/>
-
-			<!-- Right: editor + responses -->
-			<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
-				{#if selectedCommand}
-					<!-- Fullscreen toggle -->
-					<div class="flex shrink-0 items-center justify-end px-2 py-0.5">
-						<button
-							onclick={() => (fullscreen = !fullscreen)}
-							title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-							class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{#if fullscreen}
-								<MinimizeIcon class="size-3.5" />
-							{:else}
-								<MaximizeIcon class="size-3.5" />
-							{/if}
-						</button>
-					</div>
-
-					<!-- JSON editor -->
-					<div class="flex min-h-0 flex-1 overflow-hidden">
-						<JsonPayloadEditor
-							name={selectedCommand.name}
-							value={editorContent}
-							hasResponse={false}
-							{isSending}
-							{sendError}
-							{deviceValues}
-							onSend={handleSend}
-							onSendMulti={handleSendMulti}
-						/>
-					</div>
-
-					<!-- Response log (appears after first send) -->
-					{#if hasResponses}
-						<div class="max-h-48 shrink-0 overflow-y-auto border-t">
-							<div class="border-b px-3 py-1">
-								<span
-									class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-									>Responses</span
-								>
-							</div>
-							{#each responses as entry (entry.idx)}
-								<div class="border-b last:border-0">
-									<button
-										class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/50"
-										onclick={() => (entry.expanded = !entry.expanded)}
-									>
-										{#if entry.status === 'success'}
-											<CheckIcon class="size-3 shrink-0 text-emerald-500" />
-										{:else}
-											<XCircleIcon class="size-3 shrink-0 text-destructive" />
-										{/if}
-										<span class="min-w-0 flex-1 truncate font-mono text-xs"
-											>{entry.deviceName}</span
-										>
-										<span class="shrink-0 font-mono text-[10px] text-muted-foreground"
-											>{entry.durationMs}ms</span
-										>
-										<span
-											class="max-w-32 truncate font-mono text-[10px] text-muted-foreground"
-											>{entry.message}</span
-										>
-									</button>
-									{#if entry.expanded}
-										<pre
-											class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.message}</pre>
-									{/if}
-								</div>
-							{/each}
-						</div>
-					{/if}
-				{:else}
-					<p class="p-4 text-xs text-muted-foreground">Select a command</p>
-				{/if}
-			</div>
+	{#if isLoading}
+		<div class="flex flex-1 items-center justify-center">
+			<span class="text-xs text-muted-foreground">Loading…</span>
 		</div>
+	{:else if loadError}
+		<p class="px-4 py-2 text-xs text-destructive">{loadError}</p>
+	{:else if !config.selectedCommand}
+		<p class="p-4 text-xs text-muted-foreground">No command selected. Edit the widget to choose one.</p>
+	{:else if activeDescriptor}
+		<!-- Fullscreen toggle -->
+		<div class="flex shrink-0 items-center justify-end px-2 py-0.5">
+			<button
+				onclick={() => (fullscreen = !fullscreen)}
+				title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+				class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{#if fullscreen}
+					<MinimizeIcon class="size-3.5" />
+				{:else}
+					<MaximizeIcon class="size-3.5" />
+				{/if}
+			</button>
+		</div>
+
+		<!-- JSON editor -->
+		<div class="flex min-h-0 flex-1 overflow-hidden">
+			<JsonPayloadEditor
+				name={activeDescriptor.name}
+				value={editorContent}
+				hasResponse={false}
+				{isSending}
+				{sendError}
+				{deviceValues}
+				onSend={handleSend}
+				onSendMulti={handleSendMulti}
+			/>
+		</div>
+
+		<!-- Response log (appears after first send) -->
+		{#if hasResponses}
+			<div class="max-h-48 shrink-0 overflow-y-auto border-t">
+				<div class="border-b px-3 py-1">
+					<span class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+						>Responses</span
+					>
+				</div>
+				{#each responses as entry (entry.idx)}
+					<div class="border-b last:border-0">
+						<button
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/50"
+							onclick={() => (entry.expanded = !entry.expanded)}
+						>
+							{#if entry.status === 'success'}
+								<CheckIcon class="size-3 shrink-0 text-emerald-500" />
+							{:else}
+								<XCircleIcon class="size-3 shrink-0 text-destructive" />
+							{/if}
+							<span class="min-w-0 flex-1 truncate font-mono text-xs">{entry.deviceName}</span>
+							<span class="shrink-0 font-mono text-[10px] text-muted-foreground"
+								>{entry.durationMs}ms</span
+							>
+							<span class="max-w-32 truncate font-mono text-[10px] text-muted-foreground"
+								>{entry.message}</span
+							>
+						</button>
+						{#if entry.expanded}
+							<pre
+								class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.message}</pre>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
 	{/if}
 </div>

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -8,6 +8,7 @@
 	import { activityStore } from '$lib/domains/activity/stores/activity.svelte';
 	import { CHART_COLORS } from '$lib/domains/devices/utils/tlm-time';
 	import type { CommandWidgetConfig } from '../api/dashboard-api';
+	import { dashboardStore } from '../stores/dashboard.svelte';
 	import MaximizeIcon from '@lucide/svelte/icons/maximize';
 	import MinimizeIcon from '@lucide/svelte/icons/minimize';
 	import CheckIcon from '@lucide/svelte/icons/check';
@@ -15,7 +16,7 @@
 
 	let {
 		config,
-		widgetId: _widgetId,
+		widgetId,
 		onDevicesReady
 	}: {
 		config: CommandWidgetConfig;
@@ -45,6 +46,8 @@
 	let activeDescriptor = $state<CommandDescriptor | null>(null);
 	let activeDevices = $state<{ id: string; name: string; namespace: string }[]>([]);
 	let editorContent = $state('{}');
+	let deviceContents = $state<Map<string, string>>(new Map());
+	let editorHandle: { getContent: () => string } | undefined = $state(undefined);
 
 	let isSending = $state(false);
 	let sendError = $state<string | null>(null);
@@ -61,11 +64,68 @@
 		return activeDevices.map((d) => ({
 			label: `${d.name}/${d.namespace}`,
 			deviceId: d.id,
-			values: editorContent
+			values: deviceContents.get(d.id) ?? editorContent
 		}));
 	});
 
+	const initialViewMode = $derived(
+		config.savedPayloads && Object.keys(config.savedPayloads).length > 0 ? 'per-device' : 'template'
+	) as 'template' | 'per-device';
+
 	const configKey = $derived(JSON.stringify(config.target ?? {}));
+
+	// ─── Save default payload when exiting edit mode ────────────────────────────
+
+	let editModeDirty = $state(false);
+
+	// Set dirty when the user enters edit mode while the widget is loaded
+	$effect(() => {
+		if (dashboardStore.editMode && hasLoaded) editModeDirty = true;
+	});
+
+	// Save when exiting edit mode (dirty flag prevents saving on initial load)
+	$effect(() => {
+		if (!hasLoaded || dashboardStore.editMode || !editModeDirty) return;
+		untrack(() => {
+			editModeDirty = false;
+			if (!dashboardStore.activeDashboard) return;
+			const content = editorHandle?.getContent() ?? editorContent;
+			const perDevice = parsePerDeviceBlocks(content);
+			if (perDevice) {
+				dashboardStore.updateWidgetConfigInMemory(dashboardStore.activeDashboard, widgetId, {
+					...config,
+					savedPayload: undefined,
+					savedPayloads: perDevice
+				});
+			} else {
+				try {
+					JSON.parse(content);
+					dashboardStore.updateWidgetConfigInMemory(dashboardStore.activeDashboard, widgetId, {
+						...config,
+						savedPayload: content,
+						savedPayloads: undefined
+					});
+				} catch {
+					// Don't save invalid JSON
+				}
+			}
+		});
+	});
+
+	function parsePerDeviceBlocks(content: string): Record<string, string> | null {
+		if (!content.trimStart().startsWith('// ')) return null;
+		const result: Record<string, string> = {};
+		const blocks = content.split(/\n(?=\/\/ )/);
+		for (const block of blocks) {
+			const nlIdx = block.indexOf('\n');
+			if (nlIdx === -1) continue;
+			const label = block.slice(0, nlIdx).trim().replace(/^\/\/ /, '');
+			const jsonText = block.slice(nlIdx + 1).trim();
+			const dev = activeDevices.find((d) => `${d.name}/${d.namespace}` === label);
+			if (dev && jsonText) result[dev.id] = jsonText;
+		}
+		return Object.keys(result).length > 0 ? result : null;
+	}
 
 	// ─── Startup ──────────────────────────────────────────────────────────────
 
@@ -121,10 +181,23 @@
 
 			activeDescriptor = found.desc;
 			activeDevices = found.group.ids;
-			try {
-				editorContent = JSON.stringify(JSON.parse(found.desc.template || '{}'), null, 2);
-			} catch {
-				editorContent = found.desc.template || '{}';
+			if (config.savedPayloads && Object.keys(config.savedPayloads).length > 0) {
+				deviceContents = new Map(Object.entries(config.savedPayloads));
+				try {
+					editorContent = JSON.stringify(JSON.parse(found.desc.template || '{}'), null, 2);
+				} catch {
+					editorContent = found.desc.template || '{}';
+				}
+			} else if (config.savedPayload) {
+				editorContent = config.savedPayload;
+				deviceContents = new Map();
+			} else {
+				try {
+					editorContent = JSON.stringify(JSON.parse(found.desc.template || '{}'), null, 2);
+				} catch {
+					editorContent = found.desc.template || '{}';
+				}
+				deviceContents = new Map();
 			}
 
 			const allDevices = groups.flatMap((g) => g.ids);
@@ -297,8 +370,10 @@
 		<!-- JSON editor -->
 		<div class="flex min-h-16 flex-1 overflow-hidden">
 			<JsonPayloadEditor
+				bind:this={editorHandle}
 				name={activeDescriptor.name}
 				value={editorContent}
+				{initialViewMode}
 				hasResponse={false}
 				{isSending}
 				{sendError}

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -27,6 +27,7 @@
 	// ─── Types ────────────────────────────────────────────────────────────────
 
 	type CmdResponseEntry = {
+		idx: number;
 		deviceId: string;
 		deviceName: string;
 		status: 'success' | 'error';
@@ -84,6 +85,10 @@
 		}));
 	});
 
+	const configKey = $derived(
+		JSON.stringify(config.target ?? {})
+	);
+
 	// ─── Startup ──────────────────────────────────────────────────────────────
 
 	$effect(() => {
@@ -92,6 +97,14 @@
 		} else {
 			groups = [];
 			loadError = null;
+		}
+	});
+
+	$effect(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		configKey;
+		if (mirStore.mir && untrack(() => hasLoaded)) {
+			untrack(loadCommands);
 		}
 	});
 
@@ -134,11 +147,11 @@
 					}
 				}
 			}
+			hasLoaded = true;
 		} catch (err) {
 			loadError = err instanceof Error ? err.message : 'Failed to load commands';
 		} finally {
 			isLoading = false;
-			hasLoaded = true;
 		}
 	}
 
@@ -188,7 +201,7 @@
 		deviceName: string,
 		text: string,
 		dryRun: boolean
-	): Promise<CmdResponseEntry> {
+	): Promise<Omit<CmdResponseEntry, 'idx'>> {
 		const start = performance.now();
 		try {
 			const target = new DeviceTarget({ ids: [deviceId] });
@@ -233,24 +246,30 @@
 		responses = [];
 		hasResponses = true;
 
-		const results = await Promise.allSettled(
-			selectedGroupDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
-		);
+		try {
+			const results = await Promise.allSettled(
+				selectedGroupDevices.map((dev) => sendToDevice(mir, dev.id, dev.name, text, dryRun))
+			);
 
-		responses = results.map((r) =>
-			r.status === 'fulfilled'
-				? r.value
-				: {
-						deviceId: '',
-						deviceName: 'unknown',
-						status: 'error' as const,
-						message: String(r.reason),
-						durationMs: 0,
-						expanded: false
-					}
-		);
-
-		isSending = false;
+			responses = results.map((r, i) =>
+				r.status === 'fulfilled'
+					? { ...r.value, idx: i }
+					: {
+							idx: i,
+							deviceId: '',
+							deviceName: 'unknown',
+							status: 'error' as const,
+							message: String(r.reason),
+							durationMs: 0,
+							expanded: false
+						}
+			);
+		} catch (err) {
+			sendError = err instanceof Error ? err.message : 'Send failed';
+			hasResponses = false;
+		} finally {
+			isSending = false;
+		}
 	}
 
 	// ─── Send (per-device) ────────────────────────────────────────────────────
@@ -264,29 +283,35 @@
 		responses = [];
 		hasResponses = true;
 
-		const results = await Promise.allSettled(
-			[...payloads.entries()].map(([deviceId, text]) => {
-				const dev =
-					selectedGroupDevices.find((d) => d.id === deviceId) ??
-					({ id: deviceId, name: deviceId, namespace: 'default' } as const);
-				return sendToDevice(mir, dev.id, dev.name, text, dryRun);
-			})
-		);
+		try {
+			const results = await Promise.allSettled(
+				[...payloads.entries()].map(([deviceId, text]) => {
+					const dev =
+						selectedGroupDevices.find((d) => d.id === deviceId) ??
+						({ id: deviceId, name: deviceId, namespace: 'default' } as const);
+					return sendToDevice(mir, dev.id, dev.name, text, dryRun);
+				})
+			);
 
-		responses = results.map((r) =>
-			r.status === 'fulfilled'
-				? r.value
-				: {
-						deviceId: '',
-						deviceName: 'unknown',
-						status: 'error' as const,
-						message: String(r.reason),
-						durationMs: 0,
-						expanded: false
-					}
-		);
-
-		isSending = false;
+			responses = results.map((r, i) =>
+				r.status === 'fulfilled'
+					? { ...r.value, idx: i }
+					: {
+							idx: i,
+							deviceId: '',
+							deviceName: 'unknown',
+							status: 'error' as const,
+							message: String(r.reason),
+							durationMs: 0,
+							expanded: false
+						}
+			);
+		} catch (err) {
+			sendError = err instanceof Error ? err.message : 'Send failed';
+			hasResponses = false;
+		} finally {
+			isSending = false;
+		}
 	}
 </script>
 
@@ -360,7 +385,7 @@
 									>Responses</span
 								>
 							</div>
-							{#each responses as entry (entry.deviceId + entry.deviceName)}
+							{#each responses as entry (entry.idx)}
 								<div class="border-b last:border-0">
 									<button
 										class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent/50"

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -31,6 +31,7 @@
 		deviceName: string;
 		status: 'success' | 'error';
 		message: string;
+		payload: string;
 		durationMs: number;
 		expanded: boolean;
 	};
@@ -49,6 +50,7 @@
 	let sendError = $state<string | null>(null);
 	let responses = $state<CmdResponseEntry[]>([]);
 	let hasResponses = $state(false);
+	let showResponses = $state(true);
 
 	let fullscreen = $state(false);
 
@@ -153,6 +155,20 @@
 		return CommandResponseStatus[status] ?? 'OK';
 	}
 
+	function decodePayload(bytes: Uint8Array): string {
+		if (!bytes || bytes.length === 0) return '';
+		try {
+			const text = new TextDecoder().decode(bytes);
+			try {
+				return JSON.stringify(JSON.parse(text), null, 2);
+			} catch {
+				return text;
+			}
+		} catch {
+			return `<binary ${bytes.length}b>`;
+		}
+	}
+
 	async function sendToDevice(
 		mir: NonNullable<typeof mirStore.mir>,
 		deviceId: string,
@@ -171,6 +187,7 @@
 			const resp = result.get(deviceId) ?? [...result.values()][0];
 			const success = resp ? isResponseSuccess(resp.status) : true;
 			const message = resp ? responseMessage(resp.status, resp.error) : 'OK';
+			const payload = resp?.payload ? decodePayload(resp.payload) : '';
 			activityStore.add({
 				kind: success ? 'success' : 'error',
 				category: 'Command',
@@ -178,7 +195,7 @@
 				request: { deviceId, name: activeDescriptor!.name, text, dryRun },
 				...(success ? { response: Object.fromEntries(result) } : { error: message })
 			});
-			return { deviceId, deviceName, status: success ? 'success' : 'error', message, durationMs, expanded: false };
+			return { deviceId, deviceName, status: success ? 'success' : 'error', message, payload, durationMs, expanded: false };
 		} catch (err) {
 			const durationMs = Math.round(performance.now() - start);
 			const message = err instanceof Error ? err.message : 'Failed';
@@ -189,7 +206,7 @@
 				request: { deviceId, name: activeDescriptor!.name, text, dryRun },
 				error: message
 			});
-			return { deviceId, deviceName, status: 'error', message, durationMs, expanded: false };
+			return { deviceId, deviceName, status: 'error', message, payload: '', durationMs, expanded: false };
 		}
 	}
 
@@ -203,6 +220,7 @@
 		sendError = null;
 		responses = [];
 		hasResponses = true;
+		showResponses = true;
 
 		try {
 			const results = await Promise.allSettled(
@@ -211,7 +229,7 @@
 			responses = results.map((r, i) =>
 				r.status === 'fulfilled'
 					? { ...r.value, idx: i }
-					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), durationMs: 0, expanded: false }
+					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), payload: '', durationMs: 0, expanded: false }
 			);
 		} catch (err) {
 			sendError = err instanceof Error ? err.message : 'Send failed';
@@ -231,6 +249,7 @@
 		sendError = null;
 		responses = [];
 		hasResponses = true;
+		showResponses = true;
 
 		try {
 			const results = await Promise.allSettled(
@@ -244,7 +263,7 @@
 			responses = results.map((r, i) =>
 				r.status === 'fulfilled'
 					? { ...r.value, idx: i }
-					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), durationMs: 0, expanded: false }
+					: { idx: i, deviceId: '', deviceName: 'unknown', status: 'error' as const, message: String(r.reason), payload: '', durationMs: 0, expanded: false }
 			);
 		} catch (err) {
 			sendError = err instanceof Error ? err.message : 'Send failed';
@@ -275,23 +294,8 @@
 	{:else if !config.selectedCommand}
 		<p class="p-4 text-xs text-muted-foreground">No command selected. Edit the widget to choose one.</p>
 	{:else if activeDescriptor}
-		<!-- Fullscreen toggle -->
-		<div class="flex shrink-0 items-center justify-end px-2 py-0.5">
-			<button
-				onclick={() => (fullscreen = !fullscreen)}
-				title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-				class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
-			>
-				{#if fullscreen}
-					<MinimizeIcon class="size-3.5" />
-				{:else}
-					<MaximizeIcon class="size-3.5" />
-				{/if}
-			</button>
-		</div>
-
 		<!-- JSON editor -->
-		<div class="flex min-h-0 flex-1 overflow-hidden">
+		<div class="flex min-h-16 flex-1 overflow-hidden">
 			<JsonPayloadEditor
 				name={activeDescriptor.name}
 				value={editorContent}
@@ -301,17 +305,36 @@
 				{deviceValues}
 				onSend={handleSend}
 				onSendMulti={handleSendMulti}
-			/>
+			>
+				{#snippet footerEnd()}
+					{#if hasResponses}
+						<button
+							onclick={() => (showResponses = !showResponses)}
+							class="ml-auto rounded px-2 py-0.5 font-mono text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+						>
+							{showResponses ? 'Hide Response' : 'Show Response'}
+						</button>
+					{/if}
+				{/snippet}
+				{#snippet headerEnd()}
+					<button
+						onclick={() => (fullscreen = !fullscreen)}
+						title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+						class="flex items-center rounded-md border border-border bg-background p-1 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+					>
+						{#if fullscreen}
+							<MinimizeIcon class="size-3.5" />
+						{:else}
+							<MaximizeIcon class="size-3.5" />
+						{/if}
+					</button>
+				{/snippet}
+			</JsonPayloadEditor>
 		</div>
 
 		<!-- Response log (appears after first send) -->
-		{#if hasResponses}
-			<div class="max-h-48 shrink-0 overflow-y-auto border-t">
-				<div class="border-b px-3 py-1">
-					<span class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-						>Responses</span
-					>
-				</div>
+		{#if hasResponses && showResponses}
+			<div class="max-h-[45%] min-h-0 shrink overflow-y-auto border-t">
 				{#each responses as entry (entry.idx)}
 					<div class="border-b last:border-0">
 						<button
@@ -328,12 +351,12 @@
 								>{entry.durationMs}ms</span
 							>
 							<span class="max-w-32 truncate font-mono text-[10px] text-muted-foreground"
-								>{entry.message}</span
+								>{entry.payload || entry.message}</span
 							>
 						</button>
 						{#if entry.expanded}
 							<pre
-								class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.message}</pre>
+								class="overflow-x-auto bg-muted/40 px-3 py-2 font-mono text-[11px] break-all whitespace-pre-wrap">{entry.payload || entry.message}</pre>
 						{/if}
 					</div>
 				{/each}

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-command.svelte
@@ -68,9 +68,9 @@
 		}));
 	});
 
-	const initialViewMode = $derived(
+	const initialViewMode: 'template' | 'per-device' = $derived(
 		config.savedPayloads && Object.keys(config.savedPayloads).length > 0 ? 'per-device' : 'template'
-	) as 'template' | 'per-device';
+	);
 
 	const configKey = $derived(JSON.stringify(config.target ?? {}));
 
@@ -145,6 +145,44 @@
 		if (mirStore.mir && untrack(() => hasLoaded)) {
 			untrack(loadCommands);
 		}
+	});
+
+	// Reset editor to saved config when entering edit mode
+	$effect(() => {
+		if (dashboardStore.editMode && mirStore.mir && hasLoaded) {
+			untrack(loadCommands);
+		}
+	});
+
+	// Flush current editor content into the draft before create() snapshots draftWidgets.
+	// isSaving is set true → tick() in create() → this effect runs → store updated → snapshot captures it.
+	// activeDashboard is read inside untrack to avoid re-triggering when updateWidgetConfigInMemory
+	// replaces activeDashboard with a new object (which would cause an infinite loop).
+	$effect(() => {
+		if (!dashboardStore.isSaving || !dashboardStore.isCreatingNew || !hasLoaded) return;
+		untrack(() => {
+			if (!dashboardStore.activeDashboard) return;
+			const content = editorHandle?.getContent() ?? editorContent;
+			const perDevice = parsePerDeviceBlocks(content);
+			if (perDevice) {
+				dashboardStore.updateWidgetConfigInMemory(dashboardStore.activeDashboard, widgetId, {
+					...config,
+					savedPayload: undefined,
+					savedPayloads: perDevice
+				});
+			} else {
+				try {
+					JSON.parse(content);
+					dashboardStore.updateWidgetConfigInMemory(dashboardStore.activeDashboard, widgetId, {
+						...config,
+						savedPayload: content,
+						savedPayloads: undefined
+					});
+				} catch {
+					// Don't save invalid JSON
+				}
+			}
+		});
 	});
 
 	async function loadCommands() {

--- a/internal/ui/web/src/lib/domains/dashboards/components/widget-telemetry.svelte
+++ b/internal/ui/web/src/lib/domains/dashboards/components/widget-telemetry.svelte
@@ -95,6 +95,7 @@
 
 	$effect(() => {
 		if (!hasLoaded) return;
+		if (!dashboardStore.editMode) return;
 
 		// Capture user-controlled state (these are the tracked dependencies)
 		const currentSelectedFields = selectedFields;
@@ -153,6 +154,37 @@
 		if (mirStore.mir && untrack(() => hasLoaded)) {
 			untrack(loadAndQuery);
 		}
+	});
+
+	// Reset view state to saved config when entering edit mode
+	$effect(() => {
+		if (dashboardStore.editMode && hasLoaded) {
+			untrack(() => {
+				splitCount = (config.splitCount ?? 1) as 1 | 2 | 3 | 4;
+				syncFields = config.syncFields ?? false;
+				enabledDeviceIds =
+					config.enabledDeviceIds?.filter((id) => deviceInfos.some((d) => d.id === id)) ??
+					deviceInfos.map((d) => d.id);
+				const valid = config.selectedFields?.filter((f) => config.fields.includes(f)) ?? [];
+				selectedFields = valid.length > 0 ? valid : config.fields.slice(0, 1);
+				syncSelectedFields = selectedFields;
+			});
+		}
+	});
+
+	// Flush view state into the draft before create() snapshots draftWidgets.
+	// isSaving is set true → tick() in create() → this effect runs → store updated → snapshot captures it.
+	$effect(() => {
+		if (!dashboardStore.isSaving || !dashboardStore.isCreatingNew || !hasLoaded) return;
+		untrack(() => {
+			dashboardStore.saveWidgetViewState(widgetId, {
+				...config,
+				selectedFields,
+				splitCount,
+				syncFields,
+				enabledDeviceIds
+			});
+		});
 	});
 
 	async function loadAndQuery() {

--- a/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
@@ -1,3 +1,4 @@
+import { tick } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import {
 	dashboardApi,
@@ -21,10 +22,7 @@ class DashboardStore {
 	isCreatingNew = $state(false);
 	error = $state<string | null>(null);
 
-	private saveTimer: ReturnType<typeof setTimeout> | null = null;
 	private _refreshCount = 0;
-	private configSaveTimer: ReturnType<typeof setTimeout> | null = null;
-	private viewStateTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	private editSnapshot: Dashboard | null = null;
 	private _preCreateDashboard: Dashboard | null = null;
 
@@ -151,12 +149,15 @@ class DashboardStore {
 
 	async create(name: string, namespace = 'default', description = '') {
 		this.isSaving = true;
+		// tick() lets widget $effects that watch isSaving flush their pending editor content
+		// (e.g. command widget saves typed payload before we snapshot draftWidgets)
+		await tick();
 		try {
-			const draftWidgets = this.isCreatingNew ? (this.activeDashboard?.spec.widgets ?? []) : [];
-			let d = await dashboardApi.create(name, namespace, description);
-			if (draftWidgets.length > 0) {
-				d = await dashboardApi.saveWidgets(d.meta.namespace, d.meta.name, draftWidgets);
-			}
+			// Use $state.snapshot to get a plain (non-proxy) copy for reliable JSON serialization
+			const draftWidgets = this.isCreatingNew
+				? ($state.snapshot(this.activeDashboard)?.spec.widgets ?? [])
+				: [];
+			const d = await dashboardApi.create(name, namespace, description, draftWidgets);
 			this.dashboards = [...this.dashboards, d];
 			this.pinnedKeys = [...this.pinnedKeys, dashboardKey(d)];
 			this._savePinnedKeys();
@@ -176,19 +177,27 @@ class DashboardStore {
 		}
 	}
 
-	async update(d: Dashboard, patch: { name?: string; namespace?: string; description?: string }) {
+	async update(d: Dashboard, patch: { name?: string; namespace?: string; description?: string; widgets?: Widget[]; refreshInterval?: number; timeMinutes?: number }) {
 		this.isSaving = true;
 		try {
 			const oldKey = dashboardKey(d);
-			const updated = await dashboardApi.update(d.meta.namespace, d.meta.name, patch);
-			const keyChanged = dashboardKey(updated) !== oldKey;
+			const serverResponse = await dashboardApi.update(d.meta.namespace, d.meta.name, patch);
+			const keyChanged = dashboardKey(serverResponse) !== oldKey;
 			if (keyChanged) {
-				this.pinnedKeys = this.pinnedKeys.map((k) => (k === oldKey ? dashboardKey(updated) : k));
+				this.pinnedKeys = this.pinnedKeys.map((k) => (k === oldKey ? dashboardKey(serverResponse) : k));
 				this._savePinnedKeys();
 			}
-			this._syncDashboard(d, updated);
-			activityStore.add({ kind: 'success', category: 'Dashboard', title: 'Updated', request: { name: updated.meta.name, namespace: updated.meta.namespace } });
-			return updated;
+			// If widgets were included in the patch, the server response is authoritative.
+			// Otherwise (rename/description-only), preserve the in-memory spec to avoid wiping unsaved widget changes.
+			const merged = patch.widgets !== undefined
+				? serverResponse
+				: (() => {
+						const inMemorySpec = this.activeDashboard?.spec ?? d.spec;
+						return { ...serverResponse, spec: { ...serverResponse.spec, widgets: inMemorySpec.widgets, refreshInterval: inMemorySpec.refreshInterval, timeMinutes: inMemorySpec.timeMinutes } };
+					})();
+			this._syncDashboard(d, merged);
+			activityStore.add({ kind: 'success', category: 'Dashboard', title: 'Updated', request: { name: serverResponse.meta.name, namespace: serverResponse.meta.namespace } });
+			return merged;
 		} catch (err) {
 			activityStore.add({ kind: 'error', category: 'Dashboard', title: 'Update Failed', error: err instanceof Error ? err.message : String(err) });
 			throw err;
@@ -222,7 +231,7 @@ class DashboardStore {
 		}
 	}
 
-	async addWidget(d: Dashboard, type: WidgetType, title: string, config: WidgetConfig) {
+	addWidget(d: Dashboard, type: WidgetType, title: string, config: WidgetConfig) {
 		const newWidget: Widget = {
 			id: crypto.randomUUID(),
 			type,
@@ -238,21 +247,22 @@ class DashboardStore {
 			this.activeDashboard = { ...d, spec: { ...d.spec, widgets: updated } };
 			return;
 		}
-		return this._persistWidgets(d, updated);
+		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
 	}
 
-	async removeWidget(d: Dashboard, widgetId: string) {
-		return this._persistWidgets(
-			d,
-			d.spec.widgets.filter((w) => w.id !== widgetId)
-		);
+	removeWidget(d: Dashboard, widgetId: string) {
+		const updated = d.spec.widgets.filter((w) => w.id !== widgetId);
+		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
 	}
 
 	updateWidgetConfigInMemory(d: Dashboard, widgetId: string, config: WidgetConfig) {
-		if (this.isCreatingNew) return;
 		const updated = (d.spec.widgets ?? []).map((w) =>
 			w.id === widgetId ? { ...w, config } : w
 		);
+		if (this.isCreatingNew) {
+			this.activeDashboard = { ...d, spec: { ...d.spec, widgets: updated } };
+			return;
+		}
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
 	}
 
@@ -267,42 +277,22 @@ class DashboardStore {
 	}
 
 	saveWidgetConfig(d: Dashboard, widgetId: string, config: WidgetConfig) {
-		if (this.isCreatingNew) return;
 		const updated = (d.spec.widgets ?? []).map((w) =>
 			w.id === widgetId ? { ...w, config } : w
 		);
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
-
-		if (this.configSaveTimer) clearTimeout(this.configSaveTimer);
-		this.configSaveTimer = setTimeout(() => {
-			if (!this.activeDashboard) return;
-			this._persistWidgets(
-				this.activeDashboard,
-				this.activeDashboard.spec.widgets,
-				this.activeDashboard.spec.refreshInterval,
-				this.activeDashboard.spec.timeMinutes
-			);
-		}, 1000);
 	}
 
 	saveWidgetViewState(widgetId: string, config: WidgetConfig) {
-		if (this.isCreatingNew) return;
-		const existing = this.viewStateTimers.get(widgetId);
-		if (existing) clearTimeout(existing);
-		const timer = setTimeout(() => {
-			this.viewStateTimers.delete(widgetId);
-			if (!this.activeDashboard) return;
-			const updated = (this.activeDashboard.spec.widgets ?? []).map((w) =>
-				w.id === widgetId ? { ...w, config } : w
-			);
-			this._persistWidgets(
-				this.activeDashboard,
-				updated,
-				this.activeDashboard.spec.refreshInterval,
-				this.activeDashboard.spec.timeMinutes
-			);
-		}, 1000);
-		this.viewStateTimers.set(widgetId, timer);
+		if (!this.activeDashboard) return;
+		const updated = (this.activeDashboard.spec.widgets ?? []).map((w) =>
+			w.id === widgetId ? { ...w, config } : w
+		);
+		if (this.isCreatingNew) {
+			this.activeDashboard = { ...this.activeDashboard, spec: { ...this.activeDashboard.spec, widgets: updated } };
+			return;
+		}
+		this._syncDashboard(this.activeDashboard, { ...this.activeDashboard, spec: { ...this.activeDashboard.spec, widgets: updated } });
 	}
 
 	saveLayout(d: Dashboard, layoutItems: Pick<Widget, 'id' | 'x' | 'y' | 'w' | 'h'>[]) {
@@ -315,22 +305,21 @@ class DashboardStore {
 			this.activeDashboard = { ...d, spec: { ...d.spec, widgets: updated } };
 			return;
 		}
-		// Optimistic update so the grid doesn't flicker during drag.
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
-
-		if (this.saveTimer) clearTimeout(this.saveTimer);
-		this.saveTimer = setTimeout(() => {
-			if (!this.activeDashboard) return;
-			const current = this.activeDashboard;
-			const withPositions = current.spec.widgets.map((w) => {
-				const pos = posMap.get(w.id);
-				return pos ? { ...w, ...pos } : w;
-			});
-			this._persistWidgets(current, withPositions, current.spec.refreshInterval, current.spec.timeMinutes);
-		}, 1000);
 	}
 
-	enterEditMode(): { name: string; namespace: string } {
+	async enterEditMode(): Promise<{ name: string; namespace: string }> {
+		if (this.activeDashboard && !this.isCreatingNew) {
+			try {
+				const fresh = await dashboardApi.get(
+					this.activeDashboard.meta.namespace,
+					this.activeDashboard.meta.name
+				);
+				this._syncDashboard(this.activeDashboard, fresh);
+			} catch {
+				// If fetch fails, proceed with current in-memory state
+			}
+		}
 		this.editSnapshot = this.activeDashboard
 			? structuredClone($state.snapshot(this.activeDashboard))
 			: null;
@@ -343,10 +332,6 @@ class DashboardStore {
 
 	saveEditMode() {
 		this.editSnapshot = null;
-		if (this.saveTimer) { clearTimeout(this.saveTimer); this.saveTimer = null; }
-		if (this.configSaveTimer) { clearTimeout(this.configSaveTimer); this.configSaveTimer = null; }
-		for (const t of this.viewStateTimers.values()) clearTimeout(t);
-		this.viewStateTimers.clear();
 		this.editMode = false;
 	}
 
@@ -355,45 +340,15 @@ class DashboardStore {
 			this._syncDashboard(this.activeDashboard!, this.editSnapshot);
 			this.editSnapshot = null;
 		}
-		if (this.saveTimer) {
-			clearTimeout(this.saveTimer);
-			this.saveTimer = null;
-		}
-		if (this.configSaveTimer) {
-			clearTimeout(this.configSaveTimer);
-			this.configSaveTimer = null;
-		}
 		this.editMode = false;
 	}
 
 	saveRefreshInterval(d: Dashboard, interval: number) {
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, refreshInterval: interval } });
-
-		if (this.configSaveTimer) clearTimeout(this.configSaveTimer);
-		this.configSaveTimer = setTimeout(() => {
-			if (!this.activeDashboard) return;
-			this._persistWidgets(
-				this.activeDashboard,
-				this.activeDashboard.spec.widgets,
-				this.activeDashboard.spec.refreshInterval,
-				this.activeDashboard.spec.timeMinutes
-			);
-		}, 1000);
 	}
 
 	saveTimeMinutes(d: Dashboard, minutes: number) {
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, timeMinutes: minutes } });
-
-		if (this.configSaveTimer) clearTimeout(this.configSaveTimer);
-		this.configSaveTimer = setTimeout(() => {
-			if (!this.activeDashboard) return;
-			this._persistWidgets(
-				this.activeDashboard,
-				this.activeDashboard.spec.widgets,
-				this.activeDashboard.spec.refreshInterval,
-				this.activeDashboard.spec.timeMinutes
-			);
-		}, 1000);
 	}
 
 	private async _persistWidgets(d: Dashboard, widgets: Widget[], refreshInterval?: number, timeMinutes?: number) {

--- a/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
@@ -248,6 +248,24 @@ class DashboardStore {
 		);
 	}
 
+	updateWidgetConfigInMemory(d: Dashboard, widgetId: string, config: WidgetConfig) {
+		if (this.isCreatingNew) return;
+		const updated = (d.spec.widgets ?? []).map((w) =>
+			w.id === widgetId ? { ...w, config } : w
+		);
+		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
+	}
+
+	persistActiveDashboard() {
+		if (!this.activeDashboard || this.isCreatingNew) return;
+		return this._persistWidgets(
+			this.activeDashboard,
+			this.activeDashboard.spec.widgets,
+			this.activeDashboard.spec.refreshInterval,
+			this.activeDashboard.spec.timeMinutes
+		);
+	}
+
 	saveWidgetConfig(d: Dashboard, widgetId: string, config: WidgetConfig) {
 		if (this.isCreatingNew) return;
 		const updated = (d.spec.widgets ?? []).map((w) =>
@@ -301,10 +319,15 @@ class DashboardStore {
 		this._syncDashboard(d, { ...d, spec: { ...d.spec, widgets: updated } });
 
 		if (this.saveTimer) clearTimeout(this.saveTimer);
-		this.saveTimer = setTimeout(
-			() => this._persistWidgets({ ...d, spec: { ...d.spec, widgets: updated } }, updated),
-			1000
-		);
+		this.saveTimer = setTimeout(() => {
+			if (!this.activeDashboard) return;
+			const current = this.activeDashboard;
+			const withPositions = current.spec.widgets.map((w) => {
+				const pos = posMap.get(w.id);
+				return pos ? { ...w, ...pos } : w;
+			});
+			this._persistWidgets(current, withPositions, current.spec.refreshInterval, current.spec.timeMinutes);
+		}, 1000);
 	}
 
 	enterEditMode(): { name: string; namespace: string } {
@@ -320,6 +343,10 @@ class DashboardStore {
 
 	saveEditMode() {
 		this.editSnapshot = null;
+		if (this.saveTimer) { clearTimeout(this.saveTimer); this.saveTimer = null; }
+		if (this.configSaveTimer) { clearTimeout(this.configSaveTimer); this.configSaveTimer = null; }
+		for (const t of this.viewStateTimers.values()) clearTimeout(t);
+		this.viewStateTimers.clear();
 		this.editMode = false;
 	}
 

--- a/internal/ui/web/src/lib/domains/devices/components/commands/json-payload-editor.svelte
+++ b/internal/ui/web/src/lib/domains/devices/components/commands/json-payload-editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
+	import type { Snippet } from 'svelte';
 	import { EditorView, basicSetup } from 'codemirror';
 	import { Compartment } from '@codemirror/state';
 	import { json as jsonLang } from '@codemirror/lang-json';
@@ -14,7 +15,9 @@
 	import FlaskConicalIcon from '@lucide/svelte/icons/flask-conical';
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import { SvelteMap } from 'svelte/reactivity';
+	import * as Popover from '$lib/shared/components/shadcn/popover';
 
 	type DeviceValue = { label: string; deviceId: string; values: string };
 
@@ -28,7 +31,9 @@
 		showDryRun = true,
 		onSend,
 		deviceValues,
-		onSendMulti
+		onSendMulti,
+		headerEnd,
+		footerEnd
 	}: {
 		name: string;
 		nameError?: string;
@@ -40,6 +45,8 @@
 		onSend: (dryRun: boolean, text: string) => void;
 		deviceValues?: DeviceValue[];
 		onSendMulti?: (dryRun: boolean, payloads: Map<string, string>) => void;
+		headerEnd?: Snippet;
+		footerEnd?: Snippet;
 	} = $props();
 
 	let viewMode = $state<'template' | 'per-device'>('template');
@@ -55,6 +62,9 @@
 	let isVimMode = $derived(editorPrefs.vim);
 	let copied = $state(false);
 	let localError = $state<string | null>(null);
+	let headerWidth = $state(9999);
+	const compact = $derived(headerWidth < 300);
+	let overflowOpen = $state(false);
 
 	let cmEl = $state<HTMLElement | null>(null);
 	let cmView: EditorView | null = null;
@@ -158,42 +168,95 @@
 
 <div class="flex flex-1 flex-col overflow-hidden {hasResponse ? 'border-r' : ''}">
 	<!-- Header: name + error badge + vim toggle + copy -->
-	<div class="flex items-center gap-2 border-b px-4 py-2">
-		<span class="font-mono text-sm font-medium">{name}</span>
+	<div class="flex items-center gap-2 border-b px-4 py-2" bind:clientWidth={headerWidth}>
+		<span class="min-w-0 truncate font-mono text-sm font-medium">{name}</span>
 		{#if nameError}
-			<Badge variant="destructive" class="text-xs">{nameError}</Badge>
+			<Badge variant="destructive" class="shrink-0 text-xs">{nameError}</Badge>
 		{/if}
-		<div class="ml-auto flex items-center gap-1">
-			{#if deviceValues && deviceValues.length > 0}
+		<div class="ml-auto flex shrink-0 items-center gap-1">
+			{#if !compact}
+				{#if deviceValues && deviceValues.length > 0}
+					<button
+						onclick={() => (viewMode = viewMode === 'per-device' ? 'template' : 'per-device')}
+						class="rounded px-2 py-0.5 font-mono text-[10px] transition-colors {viewMode ===
+						'per-device'
+							? 'bg-secondary text-secondary-foreground'
+							: 'text-muted-foreground hover:text-foreground'}"
+					>
+						{viewMode === 'per-device' ? 'PER DEVICE' : 'TEMPLATE'}
+					</button>
+				{/if}
 				<button
-					onclick={() => (viewMode = viewMode === 'per-device' ? 'template' : 'per-device')}
-					class="rounded px-2 py-0.5 font-mono text-[10px] transition-colors {viewMode ===
-					'per-device'
+					onclick={toggleVim}
+					class="rounded px-2 py-0.5 font-mono text-[10px] transition-colors {isVimMode
 						? 'bg-secondary text-secondary-foreground'
 						: 'text-muted-foreground hover:text-foreground'}"
 				>
-					{viewMode === 'per-device' ? 'PER DEVICE' : 'TEMPLATE'}
+					VIM
 				</button>
+				<button
+					onclick={handleCopy}
+					class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+					title="Copy"
+				>
+					{#if copied}
+						<CheckIcon class="size-3.5 text-emerald-500" />
+					{:else}
+						<CopyIcon class="size-3.5" />
+					{/if}
+				</button>
+				{@render headerEnd?.()}
+			{:else}
+				<!-- Compact: collapse into popover row (same as tlm-toolbar) -->
+				<Popover.Root bind:open={overflowOpen}>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<button
+								{...props}
+								title="More options"
+								class="flex items-center rounded-md border border-border bg-background px-1.5 py-1 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground {overflowOpen
+									? 'border-ring ring-1 ring-ring'
+									: ''}"
+							>
+								<ChevronDownIcon class="size-3.5" />
+							</button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content class="w-auto p-1.5 shadow-lg" align="end">
+						<div class="flex items-center gap-1">
+							{#if deviceValues && deviceValues.length > 0}
+								<button
+									onclick={() => {
+										viewMode = viewMode === 'per-device' ? 'template' : 'per-device';
+										overflowOpen = false;
+									}}
+									class="flex items-center gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-[10px] text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground {viewMode === 'per-device' ? 'border-ring text-foreground ring-1 ring-ring' : ''}"
+								>
+									{viewMode === 'per-device' ? 'PER DEVICE' : 'TEMPLATE'}
+								</button>
+							{/if}
+							<button
+								onclick={() => { toggleVim(); overflowOpen = false; }}
+								class="flex items-center gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-[10px] text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground {isVimMode ? 'border-ring text-foreground ring-1 ring-ring' : ''}"
+							>
+								VIM
+							</button>
+							<button
+								onclick={() => { handleCopy(); overflowOpen = false; }}
+								class="flex items-center gap-1 rounded-md border border-border bg-background p-1 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+								title="Copy"
+							>
+								{#if copied}
+									<CheckIcon class="size-3.5 text-emerald-500" />
+								{:else}
+									<CopyIcon class="size-3.5" />
+								{/if}
+							</button>
+							{@render headerEnd?.()}
+						</div>
+					</Popover.Content>
+				</Popover.Root>
 			{/if}
-			<button
-				onclick={toggleVim}
-				class="rounded px-2 py-0.5 font-mono text-[10px] transition-colors {isVimMode
-					? 'bg-secondary text-secondary-foreground'
-					: 'text-muted-foreground hover:text-foreground'}"
-			>
-				VIM
-			</button>
-			<button
-				onclick={handleCopy}
-				class="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
-				title="Copy"
-			>
-				{#if copied}
-					<CheckIcon class="size-3.5 text-emerald-500" />
-				{:else}
-					<CopyIcon class="size-3.5" />
-				{/if}
-			</button>
 		</div>
 	</div>
 
@@ -204,18 +267,18 @@
 	></div>
 
 	<!-- Action buttons -->
-	<div class="flex items-center gap-1 border-t px-4 py-2">
+	<div class="flex items-center gap-1 border-t px-3 py-0.5">
 		<Button
 			variant="ghost"
 			size="sm"
 			disabled={isSending}
 			onclick={() => submit(false)}
-			class="gap-1.5"
+			class="h-7 gap-1 px-2 text-xs"
 		>
 			{#if isSending}
 				<Spinner class="size-3" />
 			{:else}
-				<SendIcon class="size-3.5" />
+				<SendIcon class="size-3" />
 			{/if}
 			Send
 		</Button>
@@ -225,12 +288,12 @@
 				size="sm"
 				disabled={isSending}
 				onclick={() => submit(true)}
-				class="gap-1.5 text-muted-foreground"
+				class="h-7 gap-1 px-2 text-xs text-muted-foreground"
 			>
 				{#if isSending}
 					<Spinner class="size-3" />
 				{:else}
-					<FlaskConicalIcon class="size-3.5" />
+					<FlaskConicalIcon class="size-3" />
 				{/if}
 				Dry Run
 			</Button>
@@ -238,5 +301,6 @@
 		{#if displayError}
 			<p class="ml-2 text-xs text-destructive">{displayError}</p>
 		{/if}
+		{@render footerEnd?.()}
 	</div>
 </div>

--- a/internal/ui/web/src/lib/domains/devices/components/commands/json-payload-editor.svelte
+++ b/internal/ui/web/src/lib/domains/devices/components/commands/json-payload-editor.svelte
@@ -29,6 +29,7 @@
 		isSending,
 		sendError,
 		showDryRun = true,
+		initialViewMode = 'template',
 		onSend,
 		deviceValues,
 		onSendMulti,
@@ -42,6 +43,7 @@
 		isSending: boolean;
 		sendError: string | null;
 		showDryRun?: boolean;
+		initialViewMode?: 'template' | 'per-device';
 		onSend: (dryRun: boolean, text: string) => void;
 		deviceValues?: DeviceValue[];
 		onSendMulti?: (dryRun: boolean, payloads: Map<string, string>) => void;
@@ -49,7 +51,11 @@
 		footerEnd?: Snippet;
 	} = $props();
 
-	let viewMode = $state<'template' | 'per-device'>('template');
+	export function getContent(): string {
+		return cmView ? cmView.state.doc.toString() : displayValue;
+	}
+
+	let viewMode = $state<'template' | 'per-device'>(initialViewMode);
 	let isMultiValues = $derived(viewMode === 'per-device' && (deviceValues?.length ?? 0) > 0);
 
 	let displayValue = $derived.by(() => {


### PR DESCRIPTION
<!-- Brief description of the changes -->
- Command widget rewrite: full multi-device support — device pills, per-device JSON payload editor (template or per-device mode),
  broadcast/individual send, response log with expandable entries, fullscreen mode
  - Command selection moved to add-widget wizard: the wizard now fetches available commands for the target at config time, so the widget opens ready
  to use
  - Widget config persists on dashboard save: isSaving + tick() flush pattern ensures all widget view state (command editor content, telemetry field
  selections, split count, enabled devices) is captured before the snapshot is taken — works for both create and edit flows
  - Single request on save: PUT /api/v1/dashboards/{ns}/{name} now accepts widgets, refreshInterval, and timeMinutes in the spec body, eliminating
  the separate /widgets sub-request on rename+save
  - Delete confirm label fixed: namespace/name order was inverted in the confirmation hint
  - Edit mode reset: entering edit mode re-fetches the dashboard from the server and resets all widget view state to the saved config, discarding
  in-session unsaved changes



## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Testing Done
<!-- Describe the testing you've done -->
- [ ] Manual tests
- [ ] Automated tests added
- [ ] No tests required

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues here using #issue-number -->
Closes #
