### PR TITLE
Updated config file of mir serve

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -9,9 +9,12 @@
   - [ ] configure https
   - [ ] configure auths
 - [ ] deployment for Cockpit
+  - [x] rework config of Mir serve 
+    - [x] check srv
+    - [x] enabled/desable of each module
   - [ ] binary
-    - [ ] test cockpit
-    - [ ] test tls, auth and wss
+    - [x] test cockpit
+    - [x] test tls, auth and wss
   - [ ] compose
     - [x] update config
     - [ ] test cockpit
@@ -25,7 +28,7 @@
   - [x] Setup local with creds to test
 - [ ] Cockpit
   - [ ] dashboard per context
-  - [ ] mir serve, how it load context list
+  - [x] mir serve, how it load context list
   
 ### Bug
 

--- a/cmds/mir/main.go
+++ b/cmds/mir/main.go
@@ -173,9 +173,9 @@ func setupMirConn(k *kong.Context, log zerolog.Logger, ctx ui.Context) error {
 	}
 
 	opts := append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionHandlers(log)...)
-	opts = append(opts, mir.WithUserCredentials(ctx.Credentials))
-	opts = append(opts, mir.WithRootCA(ctx.RootCA))
-	opts = append(opts, mir.WithClientCertificate(ctx.TlsCert, ctx.TlsKey))
+	opts = append(opts, mir.WithUserCredentials(ctx.Sec.Credentials))
+	opts = append(opts, mir.WithRootCA(ctx.Sec.RootCA))
+	opts = append(opts, mir.WithClientCertificate(ctx.Sec.TlsCert, ctx.Sec.TlsKey))
 	m, err := mir.Connect(AppName, ctx.Target, opts...)
 	if err != nil {
 		log.Err(err).Msg("error connection to Mir server")

--- a/infra/compose/mir/compose.yaml
+++ b/infra/compose/mir/compose.yaml
@@ -1,9 +1,10 @@
 services:
   mir:
-    image: ghcr.io/maxthom/mir:${MIR_VERSION:-latest}
+    image: ghcr.io/maxthom/mir:${MIR_VERSION:-main--7b90a67}
     ports:
       - "3015:3015"
     volumes:
       - ./local-config.yaml:/home/mir/.config/mir/mir.yaml
+      - ./local-contexts.yaml:/home/mir/.config/mir/cli.yaml
     command: serve
     restart: unless-stopped

--- a/infra/compose/mir/compose.yaml
+++ b/infra/compose/mir/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mir:
-    image: ghcr.io/maxthom/mir:${MIR_VERSION:-main--7b90a67}
+    image: ghcr.io/maxthom/mir:${MIR_VERSION:-latest}
     ports:
       - "3015:3015"
     volumes:

--- a/infra/compose/mir/local-config.yaml
+++ b/infra/compose/mir/local-config.yaml
@@ -1,9 +1,25 @@
 mir:
-  url: "nats://local_mir_support-nats-1:4222"
   logLevel: "info"
-  httpPort: 3015
+  http:
+    port: 3015
+    tlsCert: ""
+    tlsKey: ""
+  core:
+    deviceOnlineFlush: 7s
+    deviceOfflineFlush: 12s
+    deviceOfflineAfter: 30s
+  event:
+    flushInterval: 5s
+  cockpit:
+    allowedOrigins: []
+    githubOwner: MaxThom
+    githubRepo: mir
+nats:
+  url: "nats://local_mir_support-nats-1:4222"
   credentials: ""
   rootCA: ""
+  tlsCert: ""
+  tlsKey: ""
 surreal:
   url: "ws://local_mir_support-surrealdb-1:8000/rpc"
   namespace: "global"
@@ -15,3 +31,7 @@ influx:
   token: "mir-operator-token"
   org: "Mir"
   bucket: "mir"
+  batchSize: 1000
+  flushInterval: 1000
+  retryBufferLimit: 1073741824
+  gzip: false

--- a/infra/compose/mir/local-config.yaml
+++ b/infra/compose/mir/local-config.yaml
@@ -5,12 +5,21 @@ mir:
     tlsCert: ""
     tlsKey: ""
   core:
+    enabled: true
     deviceOnlineFlush: 7s
     deviceOfflineFlush: 12s
     deviceOfflineAfter: 30s
+  prototlm:
+    enabled: true
+  protocmd:
+    enabled: true
+  protocfg:
+    enabled: true
   event:
+    enabled: true
     flushInterval: 5s
   cockpit:
+    enabled: true
     allowedOrigins: []
     githubOwner: MaxThom
     githubRepo: mir

--- a/infra/compose/mir/local-contexts.yaml
+++ b/infra/compose/mir/local-contexts.yaml
@@ -1,0 +1,14 @@
+# /home/maxthom/.config/mir/cli.yaml
+logLevel: info
+currentContext: local
+contexts:
+  - name: local
+    target: nats://localhost:4222
+    webTarget: ws://localhost:9222
+    grafana: localhost:3000
+    sec:
+      rootCA: ""
+      tlsCert: ""
+      tlsKey: ""
+      credentials: ""
+      password: ""

--- a/internal/servers/abstract.go
+++ b/internal/servers/abstract.go
@@ -1,0 +1,7 @@
+package servers
+
+// Server defines the interface for a server that can serve requests and shutdown gracefully
+type Server interface {
+	Serve() error
+	Shutdown() error
+}

--- a/internal/servers/cockpit_srv/config_handler.go
+++ b/internal/servers/cockpit_srv/config_handler.go
@@ -74,7 +74,7 @@ func (s *CockpitServer) configHandler(w http.ResponseWriter, r *http.Request) {
 			Name:    ctx.Name,
 			Target:  toWebSocketTarget(ctx.Target, ctx.WebTarget),
 			Grafana: ctx.Grafana,
-			Secured: ctx.Password != "",
+			Secured: ctx.Sec.Password != "",
 		}
 	}
 

--- a/internal/servers/cockpit_srv/config_handler_test.go
+++ b/internal/servers/cockpit_srv/config_handler_test.go
@@ -20,13 +20,15 @@ func TestConfigHandler_Success(t *testing.T) {
 				CurrentContext: "production",
 				Contexts: []ui.Context{
 					{
-						Name:        "local",
-						Target:      "nats://localhost:4222",
-						Grafana:     "localhost:3000",
-						Credentials: "/path/to/creds",
-						RootCA:      "/path/to/ca",
-						TlsCert:     "/path/to/cert",
-						TlsKey:      "/path/to/key",
+						Name:    "local",
+						Target:  "nats://localhost:4222",
+						Grafana: "localhost:3000",
+						Sec: ui.ContextSecurity{
+							Credentials: "/path/to/creds",
+							RootCA:      "/path/to/ca",
+							TlsCert:     "/path/to/cert",
+							TlsKey:      "/path/to/key",
+						},
 					},
 					{
 						Name:    "production",
@@ -94,13 +96,15 @@ func TestConfigHandler_SensitiveFieldsFiltered(t *testing.T) {
 				CurrentContext: "local",
 				Contexts: []ui.Context{
 					{
-						Name:        "local",
-						Target:      "nats://localhost:4222",
-						Grafana:     "localhost:3000",
-						Credentials: "/secret/credentials",
-						RootCA:      "/secret/ca.pem",
-						TlsCert:     "/secret/cert.pem",
-						TlsKey:      "/secret/key.pem",
+						Name:    "local",
+						Target:  "nats://localhost:4222",
+						Grafana: "localhost:3000",
+						Sec: ui.ContextSecurity{
+							Credentials: "/secret/credentials",
+							RootCA:      "/secret/ca.pem",
+							TlsCert:     "/secret/cert.pem",
+							TlsKey:      "/secret/key.pem",
+						},
 					},
 				},
 			},

--- a/internal/servers/cockpit_srv/credentials_handler.go
+++ b/internal/servers/cockpit_srv/credentials_handler.go
@@ -34,8 +34,8 @@ func (s *CockpitServer) credentialsHandler(w http.ResponseWriter, r *http.Reques
 	found := false
 	for _, ctx := range s.opts.Config.Contexts {
 		if ctx.Name == contextName {
-			credPath = ctx.Credentials
-			password = ctx.Password
+			credPath = ctx.Sec.Credentials
+			password = ctx.Sec.Password
 			found = true
 			break
 		}

--- a/internal/servers/cockpit_srv/credentials_handler_test.go
+++ b/internal/servers/cockpit_srv/credentials_handler_test.go
@@ -49,7 +49,7 @@ func TestCredentialsHandler_NoPassword_WithCreds(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "local",
-				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Credentials: tmp.Name()}},
+				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Sec: ui.ContextSecurity{Credentials: tmp.Name()}}},
 			},
 		},
 	}
@@ -88,7 +88,7 @@ func TestCredentialsHandler_WithPassword_Correct(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "prod",
-				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Credentials: tmp.Name(), Password: "secret"}},
+				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Sec: ui.ContextSecurity{Credentials: tmp.Name(), Password: "secret"}}},
 			},
 		},
 	}
@@ -110,7 +110,7 @@ func TestCredentialsHandler_WithPassword_Wrong(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "prod",
-				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Password: "secret"}},
+				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Sec: ui.ContextSecurity{Password: "secret"}}},
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func TestCredentialsHandler_WithPassword_EmptyBody(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "prod",
-				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Password: "secret"}},
+				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Sec: ui.ContextSecurity{Password: "secret"}}},
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestCredentialsHandler_WithPassword_MissingField(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "prod",
-				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Password: "secret"}},
+				Contexts:       []ui.Context{{Name: "prod", Target: "nats://prod:4222", Sec: ui.ContextSecurity{Password: "secret"}}},
 			},
 		},
 	}
@@ -205,7 +205,7 @@ func TestCredentialsHandler_DefaultsToCurrentContext(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "local",
-				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Credentials: tmp.Name()}},
+				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Sec: ui.ContextSecurity{Credentials: tmp.Name()}}},
 			},
 		},
 	}
@@ -227,7 +227,7 @@ func TestCredentialsHandler_FileNotFound(t *testing.T) {
 		opts: Options{
 			Config: ui.Config{
 				CurrentContext: "local",
-				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Credentials: "/nonexistent/path.creds"}},
+				Contexts:       []ui.Context{{Name: "local", Target: "nats://localhost:4222", Sec: ui.ContextSecurity{Credentials: "/nonexistent/path.creds"}}},
 			},
 		},
 	}

--- a/internal/services/swarm_srvc/swarm.go
+++ b/internal/services/swarm_srvc/swarm.go
@@ -155,9 +155,9 @@ func createSwarmForDeviceGroup(swarmCfg mir_v1.Swarm, bus *nats.Conn, mirCtx ui.
 		_, err := s.AddDevices(createReqs...).
 			WithLogLevel(mir.LogLevel(swarmCfg.Spec.LogLevel)).
 			WithPrettyLogger(true).
-			WithCredentials(mirCtx.Credentials).
-			WithCerticate(mirCtx.TlsCert, mirCtx.TlsKey).
-			WithCA(mirCtx.RootCA).
+			WithCredentials(mirCtx.Sec.Credentials).
+			WithCerticate(mirCtx.Sec.TlsCert, mirCtx.Sec.TlsKey).
+			WithCA(mirCtx.Sec.RootCA).
 			WithSchemaProto(protoFiles[devGroup.Meta.Name]...).
 			Incubate()
 		if err != nil {

--- a/internal/ui/cli/context_cmd.go
+++ b/internal/ui/cli/context_cmd.go
@@ -56,7 +56,7 @@ func (d *ContextCmd) Run(cfg ui.Config) error {
 			if c.Name == data.CurrentContext {
 				st = "*" + c.Name + ""
 			}
-			sb.WriteString(fmt.Sprintf(format, st, c.Target, c.Grafana, c.Credentials))
+			sb.WriteString(fmt.Sprintf(format, st, c.Target, c.Grafana, c.Sec.Credentials))
 		}
 		out = sb.String()
 	case "json":

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -40,12 +40,14 @@ import (
 type (
 	ServeConfig struct {
 		Mir     MirCfg     `embed:"" prefix:"mir." yaml:"mir"`
+		Nats    NatsCfg    `embed:"" prefix:"nats." yaml:"nats"`
 		Surreal SurrealCfg `embed:"" prefix:"surreal." yaml:"surreal"`
 		Influx  InfluxCfg  `embed:"" prefix:"influx." yaml:"influx"`
-		Module  ModuleCfg  `embed:"" prefix:"" yaml:"module"`
 	}
 
-	ModuleCfg struct {
+	MirCfg struct {
+		LogLevel   string        `help:"Mir loglevel for each service" default:"info" yaml:"logLevel"`
+		Http       HttpCfg       `embed:"" prefix:"http." yaml:"http"`
 		Core       CoreCfg       `embed:"" prefix:"core." yaml:"core"`
 		EventStore EventStoreCfg `embed:"" prefix:"event." yaml:"event"`
 		Cockpit    CockpitCfg    `embed:"" prefix:"cockpit." yaml:"cockpit"`
@@ -67,16 +69,18 @@ type (
 		GitHubRepo     string   `help:"GitHub repo for releases feed" default:"mir" yaml:"githubRepo"`
 	}
 
-	MirCfg struct {
-		Url         string `help:"Mir server URL" default:"nats://127.0.0.1:4222" yaml:"url"`
-		Credentials string `help:"Mir JWT/NKEY credential file path" default:"" yaml:"credentials"`
-		RootCA      string `help:"Mir RootCA for TLS connection" default:"" yaml:"rootCA"`
-		TLSCert     string `help:"Mir Certificate for TLS connection" default:"" yaml:"tlsCert"`
-		TLSKey      string `help:"Mir Private Key for TLS connection" default:"" yaml:"tlsKey"`
-		LogLevel    string `help:"Mir loglevel for each service" default:"info" yaml:"logLevel"`
-		HttpPort    int    `help:"Mir http port for api" default:"3015" yaml:"httpPort"`
-		HttpTlsCert string `help:"Path to TLS certificate for HTTP server (enables HTTPS)" default:"" yaml:"httpTlsCert"`
-		HttpTlsKey  string `help:"Path to TLS private key for HTTP server" default:"" yaml:"httpTlsKey"`
+	HttpCfg struct {
+		Port    int    `help:"Mir http port for api" default:"3015" yaml:"port"`
+		TLSCert string `help:"Path to TLS certificate for HTTP server (enables HTTPS)" default:"" yaml:"tlsCert"`
+		TLSKey  string `help:"Path to TLS private key for HTTP server" default:"" yaml:"tlsKey"`
+	}
+
+	NatsCfg struct {
+		Url         string `help:"Nats server URL" default:"nats://127.0.0.1:4222" yaml:"url"`
+		Credentials string `help:"Nats JWT/NKEY credential file path" default:"" yaml:"credentials"`
+		RootCA      string `help:"Nats RootCA for TLS connection" default:"" yaml:"rootCA"`
+		TLSCert     string `help:"Nats Certificate for TLS connection" default:"" yaml:"tlsCert"`
+		TLSKey      string `help:"Nats Private Key for TLS connection" default:"" yaml:"tlsKey"`
 	}
 
 	SurrealCfg struct {
@@ -237,16 +241,16 @@ func (d *ServeCmd) run(
 		health.SetComponentReady(health.ComponentInflux)
 	}
 	opts := append(mir.WithDefaultReconnectOpts(), mir.WithDefaultConnectionHandlers(log)...)
-	opts = append(opts, mir.WithUserCredentials(cfg.Mir.Credentials))
-	opts = append(opts, mir.WithRootCA(cfg.Mir.RootCA))
-	opts = append(opts, mir.WithClientCertificate(cfg.Mir.TLSCert, cfg.Mir.TLSKey))
-	m, err := mir.Connect(AppName, cfg.Mir.Url, opts...)
+	opts = append(opts, mir.WithUserCredentials(cfg.Nats.Credentials))
+	opts = append(opts, mir.WithRootCA(cfg.Nats.RootCA))
+	opts = append(opts, mir.WithClientCertificate(cfg.Nats.TLSCert, cfg.Nats.TLSKey))
+	m, err := mir.Connect(AppName, cfg.Nats.Url, opts...)
 	if err != nil {
 		log.Err(err).Msg("error connecting to Mir server")
 		fmt.Println("error connecting to Mir server")
 		os.Exit(1)
 	} else if !m.Bus.IsConnected() {
-		log.Error().Str("url", cfg.Mir.Url).Str("status", m.Bus.Status().String()).Err(m.Bus.LastError()).Msg("cannot connect to Mir msg bus")
+		log.Error().Str("url", cfg.Nats.Url).Str("status", m.Bus.Status().String()).Err(m.Bus.LastError()).Msg("cannot connect to Mir msg bus")
 	}
 
 	// Services
@@ -261,9 +265,9 @@ func (d *ServeCmd) run(
 	}
 	coreSrv, err := core_srv.NewCore(log, m, mngStore, cc,
 		&core_srv.Options{
-			DeviceOnlineFlush:  cfg.Module.Core.DeviceOnlineFlush,
-			DeviceOfflineFlush: cfg.Module.Core.DeviceOfflineFlush,
-			DeviceOfflineAfter: cfg.Module.Core.DeviceOfflineAfter,
+			DeviceOnlineFlush:  cfg.Mir.Core.DeviceOnlineFlush,
+			DeviceOfflineFlush: cfg.Mir.Core.DeviceOfflineFlush,
+			DeviceOfflineAfter: cfg.Mir.Core.DeviceOfflineAfter,
 		})
 	if err != nil {
 		return err
@@ -284,7 +288,7 @@ func (d *ServeCmd) run(
 		return err
 	}
 
-	eventSrv, err := eventstore_srv.NewEventStore(log, m, mngStore, &eventstore_srv.Options{FlushInterval: cfg.Module.EventStore.FlushInterval})
+	eventSrv, err := eventstore_srv.NewEventStore(log, m, mngStore, &eventstore_srv.Options{FlushInterval: cfg.Mir.EventStore.FlushInterval})
 	if err != nil {
 		return err
 	}
@@ -302,13 +306,13 @@ func (d *ServeCmd) run(
 	}
 
 	cockpitSrv, err := cockpit_srv.NewCockpit(log, &cockpit_srv.Options{
-		AllowedOrigins: cfg.Module.Cockpit.AllowedOrigins,
+		AllowedOrigins: cfg.Mir.Cockpit.AllowedOrigins,
 		WebFS:          webFS,
 		Config:         contexts,
 		Store:          mngStore,
 		GitHub: cockpit_srv.GitHubOptions{
-			Owner: cfg.Module.Cockpit.GitHubOwner,
-			Repo:  cfg.Module.Cockpit.GitHubRepo,
+			Owner: cfg.Mir.Cockpit.GitHubOwner,
+			Repo:  cfg.Mir.Cockpit.GitHubRepo,
 		},
 	})
 	if err != nil {
@@ -319,7 +323,7 @@ func (d *ServeCmd) run(
 	cockpitSrv.RegisterRoutes(mux)
 
 	// WebServer — TLS enables HTTPS + native HTTP/2 (ALPN); plain uses h2c.
-	tlsEnabled := cfg.Mir.HttpTlsCert != "" && cfg.Mir.HttpTlsKey != ""
+	tlsEnabled := cfg.Mir.Http.TLSCert != "" && cfg.Mir.Http.TLSKey != ""
 	var handler http.Handler
 	if tlsEnabled {
 		handler = mux
@@ -327,7 +331,7 @@ func (d *ServeCmd) run(
 		handler = h2c.NewHandler(mux, &http2.Server{})
 	}
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Mir.HttpPort),
+		Addr:    fmt.Sprintf(":%d", cfg.Mir.Http.Port),
 		Handler: handler,
 	}
 
@@ -337,13 +341,13 @@ func (d *ServeCmd) run(
 	if tlsEnabled {
 		scheme = "https"
 	}
-	log.Info().Int("port", cfg.Mir.HttpPort).Bool("tls", tlsEnabled).Msg("starting cockpit web server")
+	log.Info().Int("port", cfg.Mir.Http.Port).Bool("tls", tlsEnabled).Msg("starting cockpit web server")
 	go func() {
 		defer wg.Done()
 		health.SetComponentReady(health.ComponentHttp)
 		var serveErr error
 		if tlsEnabled {
-			serveErr = server.ListenAndServeTLS(cfg.Mir.HttpTlsCert, cfg.Mir.HttpTlsKey)
+			serveErr = server.ListenAndServeTLS(cfg.Mir.Http.TLSCert, cfg.Mir.Http.TLSKey)
 		} else {
 			serveErr = server.ListenAndServe()
 		}
@@ -355,7 +359,7 @@ func (d *ServeCmd) run(
 		}
 		log.Debug().Msg("http server shutdown")
 	}()
-	log.Info().Msgf("serve Cockpit on %s://localhost:%d", scheme, cfg.Mir.HttpPort)
+	log.Info().Msgf("serve Cockpit on %s://localhost:%d", scheme, cfg.Mir.Http.Port)
 
 	if err := coreSrv.Serve(); err != nil {
 		return err

--- a/internal/ui/cli/serve_cmd.go
+++ b/internal/ui/cli/serve_cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/maxthom/mir/internal/libs/build_meta"
 	"github.com/maxthom/mir/internal/libs/external/influx"
 	"github.com/maxthom/mir/internal/libs/external/surreal"
+	"github.com/maxthom/mir/internal/servers"
 	cockpit_srv "github.com/maxthom/mir/internal/servers/cockpit_srv"
 	"github.com/maxthom/mir/internal/servers/core_srv"
 	"github.com/maxthom/mir/internal/servers/eventstore_srv"
@@ -49,21 +50,39 @@ type (
 		LogLevel   string        `help:"Mir loglevel for each service" default:"info" yaml:"logLevel"`
 		Http       HttpCfg       `embed:"" prefix:"http." yaml:"http"`
 		Core       CoreCfg       `embed:"" prefix:"core." yaml:"core"`
+		ProtoTlm   ProtoTlmCfg   `embed:"" prefix:"prototlm." yaml:"prototlm"`
+		ProtoCmd   ProtoCmdCfg   `embed:"" prefix:"protocmd." yaml:"protocmd"`
+		ProtoCfg   ProtoCfgCfg   `embed:"" prefix:"protocfg." yaml:"protocfg"`
 		EventStore EventStoreCfg `embed:"" prefix:"event." yaml:"event"`
 		Cockpit    CockpitCfg    `embed:"" prefix:"cockpit." yaml:"cockpit"`
 	}
 
 	CoreCfg struct {
+		Enabled            bool          `help:"Enable core service" default:"true" yaml:"enabled"`
 		DeviceOnlineFlush  time.Duration `help:"Device online flush interval" default:"7s" yaml:"deviceOnlineFlush"`
 		DeviceOfflineFlush time.Duration `help:"Device offline flush interval" default:"12s" yaml:"deviceOfflineFlush"`
 		DeviceOfflineAfter time.Duration `help:"Device offline after" default:"30s" yaml:"deviceOfflineAfter"`
 	}
 
+	ProtoTlmCfg struct {
+		Enabled bool `help:"Enable prototlm service" default:"true" yaml:"enabled"`
+	}
+
+	ProtoCmdCfg struct {
+		Enabled bool `help:"Enable protocmd service" default:"true" yaml:"enabled"`
+	}
+
+	ProtoCfgCfg struct {
+		Enabled bool `help:"Enable protocfg service" default:"true" yaml:"enabled"`
+	}
+
 	EventStoreCfg struct {
+		Enabled       bool          `help:"Enable eventstore service" default:"true" yaml:"enabled"`
 		FlushInterval time.Duration `help:"Event store flush interval" default:"5s" yaml:"flushInterval"`
 	}
 
 	CockpitCfg struct {
+		Enabled        bool     `help:"Enable cockpit service" default:"true" yaml:"enabled"`
 		AllowedOrigins []string `help:"CORS allowed origins" yaml:"allowedOrigins"`
 		GitHubOwner    string   `help:"GitHub owner for releases feed" default:"MaxThom" yaml:"githubOwner"`
 		GitHubRepo     string   `help:"GitHub repo for releases feed" default:"mir" yaml:"githubRepo"`
@@ -109,11 +128,6 @@ const (
 )
 
 type ServeCmd struct {
-	Core              bool   `help:"Core module is for device mangement" default:"true"`
-	Configuration     bool   `help:"Configuration module is for device properties" default:"true"`
-	Telemetry         bool   `help:"Telemetry module is for data ingestion and visualization" default:"true"`
-	Command           bool   `help:"Command module if for command and control" default:"true"`
-	Cockpit           bool   `help:"Cockpit web UI for device management and monitoring" default:"false"`
 	DisplayDefaultCfg bool   `name:"display-default-cfg" help:"Display default configuration. Can be piped to config file '> ~/.config/mir/mir.yaml'" default:"false"`
 	DisplayLoadedCfg  bool   `name:"display-cfg" help:"Display loaded configuration. Usefull for debug scenario" default:"false"`
 	ConfigFile        string `name:"server-config" help:"Set path for config path." default:"~/.config/mir/mir.yaml"`
@@ -246,11 +260,11 @@ func (d *ServeCmd) run(
 	opts = append(opts, mir.WithClientCertificate(cfg.Nats.TLSCert, cfg.Nats.TLSKey))
 	m, err := mir.Connect(AppName, cfg.Nats.Url, opts...)
 	if err != nil {
-		log.Err(err).Msg("error connecting to Mir server")
-		fmt.Println("error connecting to Mir server")
+		log.Err(err).Msg("error connecting to msg bus")
+		fmt.Println("error connecting to msg bus")
 		os.Exit(1)
 	} else if !m.Bus.IsConnected() {
-		log.Error().Str("url", cfg.Nats.Url).Str("status", m.Bus.Status().String()).Err(m.Bus.LastError()).Msg("cannot connect to Mir msg bus")
+		log.Error().Str("url", cfg.Nats.Url).Str("status", m.Bus.Status().String()).Err(m.Bus.LastError()).Msg("cannot connect to msg bus")
 	}
 
 	// Services
@@ -263,34 +277,52 @@ func (d *ServeCmd) run(
 	if err != nil {
 		return err
 	}
-	coreSrv, err := core_srv.NewCore(log, m, mngStore, cc,
-		&core_srv.Options{
-			DeviceOnlineFlush:  cfg.Mir.Core.DeviceOnlineFlush,
-			DeviceOfflineFlush: cfg.Mir.Core.DeviceOfflineFlush,
-			DeviceOfflineAfter: cfg.Mir.Core.DeviceOfflineAfter,
-		})
-	if err != nil {
-		return err
+
+	// Servers
+	srvs := map[string]servers.Server{}
+	if cfg.Mir.Core.Enabled {
+		coreSrv, err := core_srv.NewCore(log, m, mngStore, cc,
+			&core_srv.Options{
+				DeviceOnlineFlush:  cfg.Mir.Core.DeviceOnlineFlush,
+				DeviceOfflineFlush: cfg.Mir.Core.DeviceOfflineFlush,
+				DeviceOfflineAfter: cfg.Mir.Core.DeviceOfflineAfter,
+			})
+		if err != nil {
+			return err
+		}
+		srvs["core"] = coreSrv
 	}
 
-	cfgSrv, err := protocfg_srv.NewProtoCfg(log, m, mngStore, cc)
-	if err != nil {
-		return err
+	if cfg.Mir.ProtoCfg.Enabled {
+		cfgSrv, err := protocfg_srv.NewProtoCfg(log, m, mngStore, cc)
+		if err != nil {
+			return err
+		}
+		srvs["protocfg"] = cfgSrv
 	}
 
-	cmdSrv, err := protocmd_srv.NewProtoCmd(log, m, mngStore, cc)
-	if err != nil {
-		return err
+	if cfg.Mir.ProtoCmd.Enabled {
+		cmdSrv, err := protocmd_srv.NewProtoCmd(log, m, mngStore, cc)
+		if err != nil {
+			return err
+		}
+		srvs["protocmd"] = cmdSrv
 	}
 
-	tlmSrv, err := prototlm_srv.NewProtoTlm(log, m, mngStore, ts.NewInfluxTelemetryStore(ctx, cfg.Influx.Org, cfg.Influx.Bucket, lpClient), cc)
-	if err != nil {
-		return err
+	if cfg.Mir.ProtoTlm.Enabled {
+		tlmSrv, err := prototlm_srv.NewProtoTlm(log, m, mngStore, ts.NewInfluxTelemetryStore(ctx, cfg.Influx.Org, cfg.Influx.Bucket, lpClient), cc)
+		if err != nil {
+			return err
+		}
+		srvs["prototlm"] = tlmSrv
 	}
 
-	eventSrv, err := eventstore_srv.NewEventStore(log, m, mngStore, &eventstore_srv.Options{FlushInterval: cfg.Mir.EventStore.FlushInterval})
-	if err != nil {
-		return err
+	if cfg.Mir.EventStore.Enabled {
+		eventSrv, err := eventstore_srv.NewEventStore(log, m, mngStore, &eventstore_srv.Options{FlushInterval: cfg.Mir.EventStore.FlushInterval})
+		if err != nil {
+			return err
+		}
+		srvs["eventstore"] = eventSrv
 	}
 
 	// Metrics & Health
@@ -300,27 +332,29 @@ func (d *ServeCmd) run(
 	pprof.RegisterRoutesIfEnvGoPprofSet(mux)
 
 	// Cockpit
-	webFS, err := fs.Sub(ui.CockpitBuildFS, "web/build")
-	if err != nil {
-		return fmt.Errorf("failed to get web filesystem: %w", err)
-	}
+	if cfg.Mir.Cockpit.Enabled {
+		webFS, err := fs.Sub(ui.CockpitBuildFS, "web/build")
+		if err != nil {
+			return fmt.Errorf("failed to get web filesystem: %w", err)
+		}
 
-	cockpitSrv, err := cockpit_srv.NewCockpit(log, &cockpit_srv.Options{
-		AllowedOrigins: cfg.Mir.Cockpit.AllowedOrigins,
-		WebFS:          webFS,
-		Config:         contexts,
-		Store:          mngStore,
-		GitHub: cockpit_srv.GitHubOptions{
-			Owner: cfg.Mir.Cockpit.GitHubOwner,
-			Repo:  cfg.Mir.Cockpit.GitHubRepo,
-		},
-	})
-	if err != nil {
-		return err
-	}
+		cockpitSrv, err := cockpit_srv.NewCockpit(log, &cockpit_srv.Options{
+			AllowedOrigins: cfg.Mir.Cockpit.AllowedOrigins,
+			WebFS:          webFS,
+			Config:         contexts,
+			Store:          mngStore,
+			GitHub: cockpit_srv.GitHubOptions{
+				Owner: cfg.Mir.Cockpit.GitHubOwner,
+				Repo:  cfg.Mir.Cockpit.GitHubRepo,
+			},
+		})
+		if err != nil {
+			return err
+		}
 
-	// Register cockpit routes on the shared mux
-	cockpitSrv.RegisterRoutes(mux)
+		// Register cockpit routes on the shared mux
+		cockpitSrv.RegisterRoutes(mux)
+	}
 
 	// WebServer — TLS enables HTTPS + native HTTP/2 (ALPN); plain uses h2c.
 	tlsEnabled := cfg.Mir.Http.TLSCert != "" && cfg.Mir.Http.TLSKey != ""
@@ -341,7 +375,6 @@ func (d *ServeCmd) run(
 	if tlsEnabled {
 		scheme = "https"
 	}
-	log.Info().Int("port", cfg.Mir.Http.Port).Bool("tls", tlsEnabled).Msg("starting cockpit web server")
 	go func() {
 		defer wg.Done()
 		health.SetComponentReady(health.ComponentHttp)
@@ -359,26 +392,17 @@ func (d *ServeCmd) run(
 		}
 		log.Debug().Msg("http server shutdown")
 	}()
-	log.Info().Msgf("serve Cockpit on %s://localhost:%d", scheme, cfg.Mir.Http.Port)
+	log.Info().Msgf("serving http on %s://localhost:%d", scheme, cfg.Mir.Http.Port)
 
-	if err := coreSrv.Serve(); err != nil {
-		return err
-	}
-	if err := cfgSrv.Serve(); err != nil {
-		return err
-	}
-	if err := cmdSrv.Serve(); err != nil {
-		return err
-	}
-	if err := tlmSrv.Serve(); err != nil {
-		return err
-	}
-	if err := eventSrv.Serve(); err != nil {
-		return err
+	for k, srv := range srvs {
+		if err := srv.Serve(); err != nil {
+			return err
+		}
+		log.Debug().Msgf("serving %s service", k)
 	}
 
 	// Handle shutdown
-	log.Info().Msg(fmt.Sprintf("%s initialized", strings.ToUpper(AppName[:1])+AppName[1:]))
+	log.Info().Msg(fmt.Sprintf("%s Initialized", strings.ToUpper(AppName[:1])+AppName[1:]))
 	health.SetReady()
 	mir_signals.WaitForOsSignals(func() {
 		cancel()
@@ -386,21 +410,15 @@ func (d *ServeCmd) run(
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			log.Fatal().Err(err).Msg("failed to gracefully shutdown server")
 		}
-		if err := coreSrv.Shutdown(); err != nil {
-			log.Error().Err(err).Msg("failed to gracefully shutdown core server")
+
+		for k, srv := range srvs {
+			if err := srv.Shutdown(); err != nil {
+				log.Error().Err(err).Msgf("failed to gracefully shutdown %s service", k)
+			} else {
+				log.Debug().Msgf("shutdown %s service", k)
+			}
 		}
-		if err := cfgSrv.Shutdown(); err != nil {
-			log.Error().Err(err).Msg("failed to gracefully shutdown cfg server")
-		}
-		if err := cmdSrv.Shutdown(); err != nil {
-			log.Error().Err(err).Msg("failed to gracefully shutdown cmd server")
-		}
-		if err := tlmSrv.Shutdown(); err != nil {
-			log.Error().Err(err).Msg("failed to gracefully shutdown tlm server")
-		}
-		if err := eventSrv.Shutdown(); err != nil {
-			log.Error().Err(err).Msg("failed to gracefully shutdown event store server")
-		}
+
 		m.Disconnect()
 		db.Close()
 		lpClient.Close()

--- a/internal/ui/cli/swarm_cmd.go
+++ b/internal/ui/cli/swarm_cmd.go
@@ -117,9 +117,9 @@ func launchSwarm(ctx context.Context, m *mSdk.Mir, logLvl mir.LogLevel, mirCtx u
 		WithSchema(swarmv1.File_swarm_v1_demo_proto).
 		WithLogLevel(logLvl).
 		WithPrettyLogger(true).
-		WithCredentials(mirCtx.Credentials).
-		WithCerticate(mirCtx.TlsCert, mirCtx.TlsKey).
-		WithCA(mirCtx.RootCA).
+		WithCredentials(mirCtx.Sec.Credentials).
+		WithCerticate(mirCtx.Sec.TlsCert, mirCtx.Sec.TlsKey).
+		WithCA(mirCtx.Sec.RootCA).
 		Incubate()
 	if err != nil {
 		return nil, fmt.Errorf("error incubating swarm: %w", err)

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -44,10 +44,14 @@ func NewDefaultConfig() Config {
 }
 
 type Context struct {
-	Name        string `yaml:"name"`
-	Target      string `yaml:"target"`
-	WebTarget   string `yaml:"webTarget"`
-	Grafana     string `yaml:"grafana"`
+	Name      string          `yaml:"name"`
+	Target    string          `yaml:"target"`
+	WebTarget string          `yaml:"webTarget"`
+	Grafana   string          `yaml:"grafana"`
+	Sec       ContextSecurity `yaml:"sec"`
+}
+
+type ContextSecurity struct {
 	Credentials string `yaml:"credentials"`
 	RootCA      string `yaml:"rootCA"`
 	TlsCert     string `yaml:"tlsCert"`

--- a/pkgs/module/mir/mir.go
+++ b/pkgs/module/mir/mir.go
@@ -158,11 +158,11 @@ func WithDefaultReconnectOpts() []nats.Option {
 func WithDefaultConnectionHandlers(l zerolog.Logger) []nats.Option {
 	return []nats.Option{
 		nats.ErrorHandler(func(c *nats.Conn, s *nats.Subscription, err error) {
-			l.Error().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Err(err).Msg("connected to Mir Server ")
+			l.Error().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Err(err).Msg("connected to msg bus")
 		}),
 		nats.ConnectHandler(func(c *nats.Conn) {
 			health.SetComponentReady(health.ComponentNats)
-			l.Info().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Msg("connected to Mir Server ")
+			l.Info().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Msg("connected to msg bus")
 		}),
 		nats.DisconnectErrHandler(func(c *nats.Conn, err error) {
 			health.SetComponentUnready(health.ComponentNats)
@@ -171,7 +171,7 @@ func WithDefaultConnectionHandlers(l zerolog.Logger) []nats.Option {
 		}),
 		nats.ReconnectHandler(func(c *nats.Conn) {
 			health.SetComponentReady(health.ComponentNats)
-			l.Info().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Msg("reconnected to Mir Server ")
+			l.Info().Str("url", c.ConnectedUrl()).Str("status", c.Status().String()).Msg("reconnected to msg bus")
 		}),
 		nats.ClosedHandler(func(c *nats.Conn) {
 			health.SetComponentUnready(health.ComponentNats)


### PR DESCRIPTION
## Summary

- Refactored `mir serve` configuration to support per-module enable/disable flags, allowing individual server modules to be toggled on or off via config or CLI flags
- Enriched Docker Compose local config (`local-config.yaml`, `local-contexts.yaml`) with more complete serve settings and context definitions
- Cleaned up serve command structure and aligned config handling across cockpit server handlers, swarm service, and context command

## Type of Change
- [x] New feature
- [x] Refactor

## Testing Done
- [ ] Manual tests
- [ ] Automated tests added
- [ ] No tests required

## Related Issues
Closes #