### PR TITLE
Kubernetes: Cockpit TLS, NATS WebSocket, and Helm chart improvements

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -32,7 +32,7 @@
     - [x] test tls, auth and wss
   - [ ] helm
     - [x] nats websocket
-    - [ ] websocket ingress
+    - [x] websocket ingress
     - [x] configmap revamp
     - [x] context list configmap
     - [ ] tls load

--- a/TASKS.md
+++ b/TASKS.md
@@ -31,7 +31,12 @@
     - [x] test cockpit
     - [x] test tls, auth and wss
   - [ ] helm
-    - [ ] update chart with http ingress
+    - [x] nats websocket
+    - [ ] websocket ingress
+    - [x] configmap revamp
+    - [x] context list configmap
+    - [ ] tls load
+    - [ ] creds load for list
     - [ ] test cockpit
     - [ ] test tls, auth and wss
 - [x] security for Cockpit

--- a/TASKS.md
+++ b/TASKS.md
@@ -36,9 +36,11 @@
     - [x] configmap revamp
     - [x] context list configmap
     - [ ] tls load
-    - [ ] creds load for list
+    - [x] creds load for list
     - [ ] test cockpit
     - [ ] test tls, auth and wss
+    - [ ] update gitops chart
+    - [ ] update my own do deployments
 - [x] security for Cockpit
   - [x] detect if local, if so no need of password
   - [x] Setup local with creds to test

--- a/book/src/running_mir/kubernetes.md
+++ b/book/src/running_mir/kubernetes.md
@@ -68,8 +68,15 @@ nats:
     host: nats.example.com   # NATS monitor endpoint
     path: /
     pathType: Prefix
-    wsHost: mir.example.com  # Host for NATS WebSocket (can be same as Mir)
-    wsPath: /nats-ws         # Path for NATS WebSocket via ingress
+  config:
+    websocket:
+      ingress:
+        enabled: true
+        hosts:
+          - mir.example.com   # same host as Cockpit
+        path: /nats-ws
+        pathType: Prefix
+        className: ""         # nginx, traefik, etc.
   service:
     merge:
       spec:
@@ -81,7 +88,7 @@ nats:
             port: 4222
             protocol: TCP
             targetPort: nats
-          # NodePort for WebSocket, use this or ingress.wsHost/ingress.wsPath or both
+          # NodePort for WebSocket, use this or nats.config.websocket.ingress or both
           - appProtocol: tcp
             name: websocket
             nodePort: 31922
@@ -246,6 +253,9 @@ nats:
 Set `webTarget: "ws://mir.example.com/nats-ws"` in your context config.
 
 Traefik handles WebSocket upgrades natively — no additional annotations required.
+
+> For HTTPS/WSS deployments, also set `tlsSecretName` in the `ingress` block.
+> See [TLS configuration](../security/tls-serveronly.md) for the full setup.
 
 ## Security Considerations
 

--- a/book/src/running_mir/kubernetes.md
+++ b/book/src/running_mir/kubernetes.md
@@ -22,34 +22,42 @@ helm repo add mir https://charts.mirhub.io
 helm repo update
 ```
 
-### Create Image Pull Secret to access GitHub Container Registry
+### Create Image Pull Secret
 
 [Access to Mir GitHub Container Registry (ghcr.io)](../resources/access_mir_container_reg.md)
 
 ### Install Mir Chart
 
-Create a custom values file `custom.values.yaml` to pass secrets, update ingress hosts, persistences and resources:
+Create a `custom.values.yaml` with your environment-specific overrides:
 
 ```yaml
 imagePullSecrets:
   - name: ghcr-mir-secret
 
+# Configure contexts — tells the Cockpit UI how to reach NATS and Grafana
+# Need at one context for this Mir Server
+config:
+  contexts:
+    - name: "production"
+      target: "nats://<cluster-ip>:31422"      # NATS TCP for CLI/devices
+      webTarget: "ws://<nats-host>/nats-ws"    # NATS WebSocket for Cockpit
+      grafana: "http://<grafana-host>"
+      sec:
+        credentials: ""   # NATS creds file content (leave empty for open)
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""      # Cockpit UI password (leave empty to disable)
+
 ingress:
   enabled: true
-  className: ""
+  className: ""           # nginx, traefik, etc.
   annotations: {}
   hosts:
-    - host: mir.local
+    - host: mir.example.com
       paths:
         - path: /
           pathType: Prefix
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 nats:
   enabled: true
@@ -57,9 +65,11 @@ nats:
     enabled: true
     className: ""
     annotations: {}
-    host: nats-local
+    host: nats.example.com   # NATS monitor endpoint
     path: /
     pathType: Prefix
+    wsHost: mir.example.com  # Host for NATS WebSocket (can be same as Mir)
+    wsPath: /nats-ws         # Path for NATS WebSocket via ingress
   service:
     merge:
       spec:
@@ -71,6 +81,13 @@ nats:
             port: 4222
             protocol: TCP
             targetPort: nats
+          # NodePort for WebSocket, use this or ingress.wsHost/ingress.wsPath or both
+          - appProtocol: tcp
+            name: websocket
+            nodePort: 31922
+            port: 9222
+            protocol: TCP
+            targetPort: websocket
   config:
     jetstream:
       fileStore:
@@ -119,41 +136,28 @@ influxdb2:
 ### Install Chart
 
 ```bash
-# Install latest version
 helm install mir mir/mir \
   --namespace mir \
-  --create-namespace
+  --create-namespace \
   -f custom.values.yaml
 ```
-
-Default values, includes:
-
-- Load balancer on :31422
-- Mir services
-- NATS with JetStream
-- SurrealDB
-- InfluxDB
-- Service Monitors
-- Grafana Dashboards
 
 ### Access Mir
 
 ```bash
-# Access the server using the CLI on localhost
+# CLI access via NATS TCP
 mir tools config edit
-# contexts:
-#  - name: k8s
-#    target: nats://<cluster_ip>:31422
-#    grafana: <grafana_url>
-mir ctx k8s
-
-# Use
+# Set target: nats://<cluster-ip>:31422
+mir ctx production
 mir dev ls
+
+# Cockpit (web UI) — open in browser
+# http://mir.example.com
 ```
 
 ## Deployment Scenarios
 
-The chart includes several pre-configured values files for common deployment [scenarios](https://github.com/MaxThom/mir/tree/main/infra/k8s/charts/mir)
+The chart includes several pre-configured values files for common deployment [scenarios](https://github.com/MaxThom/mir/tree/main/infra/k8s/charts/mir).
 
 ### 1. Minimal Deployment (`values-minimal.yaml`)
 
@@ -166,22 +170,22 @@ helm install mir ./mir -f values-minimal.yaml
 ```
 
 **Configuration required**:
-- Update external service URLs in the config section
+- Update external service URLs in the `config` section
 - Configure authentication credentials
 - Adjust resource limits as needed
 
-### 2. Standard Deployment (`values-standard.yaml`) (Recommended and Default)
+### 2. Standard Deployment (`values-standard.yaml`) (Recommended)
 
-Deploy Mir with all infrastructure components but without monitoring.
+Deploy Mir with all infrastructure components but without a monitoring stack.
 
-**Use when**: You need a production-ready IoT platform and already have a prometheus monitoring stack or else.
+**Use when**: You need a production-ready IoT platform and manage observability separately.
 
 ```bash
 helm install mir ./mir -f values-standard.yaml
 ```
 
 **Includes**:
-- Mir services
+- Mir services + Cockpit UI
 - NATS with JetStream (3-node cluster)
 - SurrealDB with 20Gi storage
 - InfluxDB with 50Gi storage
@@ -190,7 +194,7 @@ helm install mir ./mir -f values-standard.yaml
 
 Complete deployment with all services and full observability stack.
 
-**Use when**: You need a production-ready platform with complete monitoring and logging.
+**Use when**: You need a self-contained platform with built-in monitoring and logging.
 
 ```bash
 helm install mir ./mir -f values-full.yaml
@@ -204,50 +208,84 @@ helm install mir ./mir -f values-full.yaml
 - Loki for log aggregation
 - Promtail for log collection
 
+> **Note**: When `kube-prometheus-stack` is disabled, you must also disable the monitoring CRD resources to avoid `ServiceMonitor`/`PodMonitor` errors:
+> ```yaml
+> mirServiceMonitors:
+>   enabled: false
+> mirPrometheusRules:
+>   enabled: false
+> nats:
+>   promExporter:
+>     podMonitor:
+>       enabled: false
+> ```
+
+## NATS WebSocket
+
+The Cockpit UI connects to NATS via WebSocket. Two exposure options are available:
+
+### Via NodePort (simpler)
+Directly accessible on port `31922`. Set `webTarget: "ws://localhost:31922"` in your context config.
+
+### Via Ingress (recommended for shared/production)
+Route WebSocket through the ingress controller on the same host as the Cockpit UI. Uses path `/nats-ws` to differentiate from the Mir HTTP API:
+
+```yaml
+nats:
+  ingress:
+    enabled: true
+    wsHost: mir.example.com  # Same host as Cockpit
+    wsPath: /nats-ws
+```
+
+Set `webTarget: "ws://mir.example.com/nats-ws"` in your context config.
+
+Traefik handles WebSocket upgrades natively — no additional annotations required.
+
 ## Security Considerations
 
 ### Using Secrets
 
 For production deployments, use Kubernetes secrets for sensitive data:
 
-1. Create secret files in `secret/` [directory](https://github.com/MaxThom/mir/tree/main/infra/k8s/charts/mir/secret):
-   - `mir.secret.yaml` - Mir service credentials
-   - `surreal.secret.yaml` - SurrealDB credentials
-   - `influx.secret.yaml` - InfluxDB credentials
+1. Create secret files from the templates in `secret/` [directory](https://github.com/MaxThom/mir/tree/main/infra/k8s/charts/mir/secret):
+   - `mir.secret.yaml` — Mir service credentials
+   - `surreal.secret.yaml` — SurrealDB credentials
+   - `influx.secret.yaml` — InfluxDB credentials
 
-2. Apply secrets before installing the chart:
+2. Apply secrets before installing:
 ```bash
 kubectl apply -f secret/
 ```
 
-3. Update your `custom.values.yaml`
+3. Reference secrets in your `custom.values.yaml`:
 ```yaml
 ## Mir
 secretRef: mir-secret
-## Surreal
+
+## SurrealDB
 surrealdb:
   podExtraEnv:
-  - name: SURREAL_USER
-    valueFrom:
-      secretKeyRef:
-        name: surreal-secret
-        key: SURREAL_USER
-  - name: SURREAL_PASS
-    valueFrom:
-      secretKeyRef:
-        name: surreal-secret
-        key: SURREAL_PASS
-## Influx
+    - name: SURREAL_USER
+      valueFrom:
+        secretKeyRef:
+          name: surreal-secret
+          key: SURREAL_USER
+    - name: SURREAL_PASS
+      valueFrom:
+        secretKeyRef:
+          name: surreal-secret
+          key: SURREAL_PASS
+
+## InfluxDB
 influxdb2:
   adminUser:
     existingSecret: influx-secret
 ```
 
-### Authentification and Authorization
+### Authentication and Authorization
 
-Securing the environment is done via the NSC tool. Refer to [Security Tutorial](../security/auth.md) for details on how to setup.
-
-To configure Kubernetes,
+Securing NATS with TLS and credentials is done via the NSC tool. Refer to [Security Tutorial](../security/auth.md) for setup details.
 
 ## Next Steps
 

--- a/book/src/running_mir/kubernetes.md
+++ b/book/src/running_mir/kubernetes.md
@@ -228,14 +228,19 @@ The Cockpit UI connects to NATS via WebSocket. Two exposure options are availabl
 Directly accessible on port `31922`. Set `webTarget: "ws://localhost:31922"` in your context config.
 
 ### Via Ingress (recommended for shared/production)
-Route WebSocket through the ingress controller on the same host as the Cockpit UI. Uses path `/nats-ws` to differentiate from the Mir HTTP API:
+Route WebSocket through the ingress controller on the same host as the Cockpit UI using the NATS chart's native WebSocket ingress:
 
 ```yaml
 nats:
-  ingress:
-    enabled: true
-    wsHost: mir.example.com  # Same host as Cockpit
-    wsPath: /nats-ws
+  config:
+    websocket:
+      ingress:
+        enabled: true
+        hosts:
+          - mir.example.com   # same host as Cockpit
+        path: /nats-ws
+        pathType: Prefix
+        className: traefik    # or nginx, etc.
 ```
 
 Set `webTarget: "ws://mir.example.com/nats-ws"` in your context config.

--- a/book/src/security/auth-kubernetes.md
+++ b/book/src/security/auth-kubernetes.md
@@ -261,6 +261,102 @@ NAMESPACE/NAME                                DEVICE_ID        STATUS     LAST_H
 default/dev1                                  dev1             online     2025-09-18 16:16:27  2025-09-18 16:15:18
 ```
 
+### Step 6: Configure Cockpit Context Credentials
+
+The Cockpit web UI connects to NATS on behalf of the browser. When a context requires authentication, the Mir server serves the `.creds` file to the browser via `POST /api/v1/credentials?context=<name>`. You can optionally protect this endpoint with a password gate.
+
+#### Context credentials file
+
+**Option A - Reuse the Mir server credentials**
+
+If all contexts share the same access level as the Mir server itself, point the context at the file already mounted via `authSecretRef`:
+
+```yaml
+# values-auth.yaml
+config:
+  contexts:
+    - name: "production"
+      sec:
+        credentials: "/etc/mir/mir.creds"
+```
+
+**Option B - Dedicated Cockpit client credentials**
+
+Gives the Cockpit a separate NATS user with its own scope, independent from the server's module user.
+
+```bash
+# Create client users for each context
+mir tools security add client production_ui --swarm
+mir tools security add client staging_ui --swarm
+mir tools security push
+mir tools security generate-creds production_ui -p ./production.creds
+mir tools security generate-creds staging_ui -p ./staging.creds
+```
+
+All context credentials can share a single Kubernetes secret, use a separate key per context:
+
+```bash
+kubectl create secret generic mir-cockpit-creds \
+  --from-file=production.creds=./production.creds \
+  --from-file=staging.creds=./staging.creds
+```
+
+Reference the shared secret in values, pointing each context at its own key via `credsSecretKey`:
+
+```yaml
+# values-auth.yaml
+config:
+  contexts:
+    - name: "production"
+      sec:
+        credsSecretRef: "mir-cockpit-creds"
+        credsSecretKey: "production.creds"   # auto-mounts at /etc/mir/creds/production.creds
+    - name: "staging"
+      sec:
+        credsSecretRef: "mir-cockpit-creds"
+        credsSecretKey: "staging.creds"      # auto-mounts at /etc/mir/creds/staging.creds
+```
+
+If you only have one context, `credsSecretKey` defaults to `mir.creds`, so you can omit it:
+
+```bash
+kubectl create secret generic mir-cockpit-creds --from-file=mir.creds=./cockpit_ui.creds
+```
+
+Both options can be combined with a password gate (see below).
+
+#### Context password gate
+
+Add per-context passwords to the existing `mir-secret` (the secret referenced by `secretRef`) rather than putting them in plaintext values. The key pattern is `MIR__CTX__<UPPERCASE_NAME>__PASSWORD` - hyphens in context names become underscores.
+
+```yaml
+# mir.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mir-secret
+type: Opaque
+stringData:
+  MIR__SURREAL__PASSWORD: "root"
+  MIR__INFLUX__TOKEN: "mir-operator-token"
+  # Cockpit context passwords
+  MIR__CTX__PRODUCTION__PASSWORD: "your-cockpit-password"
+  # For a context named "prod-eu": MIR__CTX__PROD_EU__PASSWORD: "..."
+```
+
+Apply and reference in values:
+
+```bash
+kubectl apply -f mir.secret.yaml
+```
+
+```yaml
+# values-auth.yaml
+secretRef: "mir-secret"
+```
+
+Restart the deployment to pick up the new secret keys. In the Cockpit, selecting a secured context will now prompt for the password before returning credentials to the browser.
+
 ### Other commands
 
 ```bash

--- a/book/src/security/tls-mutual.md
+++ b/book/src/security/tls-mutual.md
@@ -187,7 +187,11 @@ nats:
 
 ### Step 3: Configure Cockpit HTTPS (Optional)
 
-By default Cockpit serves on plain HTTP. If you want the web UI over HTTPS (so the browser uses `wss://` for its NATS WebSocket connection), configure it in `./mir-compose/mir/local-config.yaml`:
+By default Cockpit serves on plain HTTP. If you want the web UI over HTTPS (so the browser uses `wss://` for its NATS WebSocket connection), follow the steps for your deployment.
+
+#### Docker
+
+Configure in `./mir-compose/mir/local-config.yaml`:
 
 ```yaml
 mir:
@@ -219,6 +223,49 @@ contexts:
 ```
 
 Restart: `docker compose down && docker compose up`. Cockpit is now available at `https://localhost:3015`.
+
+#### Kubernetes
+
+Two options are available. TLS with Ingress or TLS with NodePort. If both are configured, you must configured your ingress to route HTTPS to the pod. It is recommended to use Ingress with a TLS secret only. Mutual TLS is not supported for Browser.
+
+Create a TLS secret from your certificate files:
+
+```bash
+kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
+```
+
+**Option A — Via Ingress (recommended)**
+
+The ingress controller terminates TLS. Mir runs on plain HTTP internally. Works with any ingress controller and cert-manager.
+
+```yaml
+ingress:
+  enabled: true
+  className: "traefik"  # or "nginx", etc.
+  hosts:
+    - host: mir.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mir-http-tls-secret
+      hosts:
+        - mir.example.com
+```
+
+**Option B — Via App (no ingress)**
+
+Mir reads the certificate directly and serves HTTPS itself. Use when there is no ingress controller.
+
+```yaml
+mirHttpTlsSecretRef: mir-http-tls-secret
+```
+
+Apply with Helm:
+
+```bash
+helm upgrade <release-name> <chart-path> -f values.yaml
+```
 
 ### Step 4: Install Certificates on Module
 

--- a/book/src/security/tls-mutual.md
+++ b/book/src/security/tls-mutual.md
@@ -226,17 +226,15 @@ Restart: `docker compose down && docker compose up`. Cockpit is now available at
 
 #### Kubernetes
 
-Two options are available. TLS with Ingress or TLS with NodePort. If both are configured, you must configured your ingress to route HTTPS to the pod. It is recommended to use Ingress with a TLS secret only. Mutual TLS is not supported for Browser.
+**Option A and B are mutually exclusive.** With ingress TLS (Option A), NATS WebSocket TLS is terminated at the ingress. Without ingress (Option B), NATS WebSocket must serve TLS directly. Mutual TLS is not supported for browser clients.
 
-Create a TLS secret from your certificate files:
+**Option A - Via Ingress (recommended)**
+
+The ingress controller terminates TLS. Mir and NATS run plain HTTP/WS internally.
 
 ```bash
 kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
 ```
-
-**Option A — Via Ingress (recommended)**
-
-The ingress controller terminates TLS. Mir runs on plain HTTP internally. Works with any ingress controller and cert-manager.
 
 ```yaml
 ingress:
@@ -251,14 +249,51 @@ ingress:
     - secretName: mir-http-tls-secret
       hosts:
         - mir.example.com
+
+nats:
+  config:
+    websocket:
+      ingress:
+        enabled: true
+        hosts:
+          - mir.example.com
+        path: /nats-ws
+        pathType: Prefix
+        className: "traefik"
+        tlsSecretName: mir-http-tls-secret
+
+config:
+  contexts:
+    - name: "production"
+      webTarget: "wss://mir.example.com/nats-ws"
 ```
 
-**Option B — Via App (no ingress)**
+**Option B - Via App (no ingress)**
 
-Mir reads the certificate directly and serves HTTPS itself. Use when there is no ingress controller.
+Mir and NATS serve TLS directly. Use when there is no ingress controller.
+
+```bash
+kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
+kubectl create secret tls nats-ws-tls-secret --cert=tls.crt --key=tls.key
+```
 
 ```yaml
 mirHttpTlsSecretRef: mir-http-tls-secret
+
+nats:
+  config:
+    websocket:
+      tls:
+        enabled: true
+        secretName: nats-ws-tls-secret
+        dir: /etc/nats-certs/websocket
+        cert: tls.crt
+        key: tls.key
+
+config:
+  contexts:
+    - name: "production"
+      webTarget: "wss://<host>:31922"  # NATS WebSocket NodePort
 ```
 
 Apply with Helm:

--- a/book/src/security/tls-serveronly.md
+++ b/book/src/security/tls-serveronly.md
@@ -109,7 +109,11 @@ nats:
 
 ### Step 3: Configure Cockpit HTTPS (Optional)
 
-By default Cockpit serves on plain HTTP. If you want the web UI over HTTPS (so the browser uses `wss://` for its NATS WebSocket connection), configure it in `./mir-compose/mir/local-config.yaml`:
+By default Cockpit serves on plain HTTP. If you want the web UI over HTTPS (so the browser uses `wss://` for its NATS WebSocket connection), follow the steps for your deployment.
+
+#### Docker
+
+Configure in `./mir-compose/mir/local-config.yaml`:
 
 ```yaml
 mir:
@@ -141,6 +145,49 @@ contexts:
 ```
 
 Restart: `docker compose down && docker compose up`. Cockpit is now available at `https://localhost:3015`.
+
+#### Kubernetes
+
+Two options are available. TLS with Ingress or TLS with NodePort. If both are configured, you must configured your ingress to route HTTPS to the pod. It is recommended to use Ingress with a TLS secret only.
+
+Create a TLS secret from your certificate files:
+
+```bash
+kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
+```
+
+**Option A — Via Ingress (recommended)**
+
+The ingress controller terminates TLS. Mir runs on plain HTTP internally. Works with any ingress controller and cert-manager.
+
+```yaml
+ingress:
+  enabled: true
+  className: "traefik"  # or "nginx", etc.
+  hosts:
+    - host: mir.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mir-http-tls-secret
+      hosts:
+        - mir.example.com
+```
+
+**Option B — Via App (no ingress)**
+
+Mir reads the certificate directly and serves HTTPS itself. Use when there is no ingress controller.
+
+```yaml
+mirHttpTlsSecretRef: mir-http-tls-secret
+```
+
+Apply with Helm:
+
+```bash
+helm upgrade <release-name> <chart-path> -f values.yaml
+```
 
 ### Step 4: Install Root Certificate on Module
 

--- a/book/src/security/tls-serveronly.md
+++ b/book/src/security/tls-serveronly.md
@@ -105,6 +105,9 @@ nats:
         dir: /etc/nats-certs/nats
         cert: tls.crt
         key: tls.key
+        merge:
+          verify: false # false = Server-Only TLS (no client cert required)
+          timeout: 2
 ```
 
 ### Step 3: Configure Cockpit HTTPS (Optional)

--- a/book/src/security/tls-serveronly.md
+++ b/book/src/security/tls-serveronly.md
@@ -148,17 +148,15 @@ Restart: `docker compose down && docker compose up`. Cockpit is now available at
 
 #### Kubernetes
 
-Two options are available. TLS with Ingress or TLS with NodePort. If both are configured, you must configured your ingress to route HTTPS to the pod. It is recommended to use Ingress with a TLS secret only.
+**Option A and B are mutually exclusive.** With ingress TLS (Option A), NATS WebSocket TLS is terminated at the ingress. Without ingress (Option B), NATS WebSocket must serve TLS directly.
 
-Create a TLS secret from your certificate files:
+**Option A - Via Ingress (recommended)**
+
+The ingress controller terminates TLS. Mir and NATS run plain HTTP/WS internally.
 
 ```bash
 kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
 ```
-
-**Option A — Via Ingress (recommended)**
-
-The ingress controller terminates TLS. Mir runs on plain HTTP internally. Works with any ingress controller and cert-manager.
 
 ```yaml
 ingress:
@@ -173,14 +171,51 @@ ingress:
     - secretName: mir-http-tls-secret
       hosts:
         - mir.example.com
+
+nats:
+  config:
+    websocket:
+      ingress:
+        enabled: true
+        hosts:
+          - mir.example.com
+        path: /nats-ws
+        pathType: Prefix
+        className: "traefik"
+        tlsSecretName: mir-http-tls-secret
+
+config:
+  contexts:
+    - name: "production"
+      webTarget: "wss://mir.example.com/nats-ws"
 ```
 
-**Option B — Via App (no ingress)**
+**Option B - Via App (no ingress)**
 
-Mir reads the certificate directly and serves HTTPS itself. Use when there is no ingress controller.
+Mir and NATS serve TLS directly. Use when there is no ingress controller.
+
+```bash
+kubectl create secret tls mir-http-tls-secret --cert=tls.crt --key=tls.key
+kubectl create secret tls nats-ws-tls-secret --cert=tls.crt --key=tls.key
+```
 
 ```yaml
 mirHttpTlsSecretRef: mir-http-tls-secret
+
+nats:
+  config:
+    websocket:
+      tls:
+        enabled: true
+        secretName: nats-ws-tls-secret
+        dir: /etc/nats-certs/websocket
+        cert: tls.crt
+        key: tls.key
+
+config:
+  contexts:
+    - name: "production"
+      webTarget: "wss://<host>:31922"  # NATS WebSocket NodePort
 ```
 
 Apply with Helm:

--- a/cmds/mir/main.go
+++ b/cmds/mir/main.go
@@ -109,6 +109,18 @@ func SetParams(k *kong.Context, d Globals, logFile *os.File) error {
 	if len(foundFiles) > 0 {
 		ui.LoadedConfigPath = foundFiles[len(foundFiles)-1]
 	}
+
+	// Koanf cannot deep-merge env vars into slice elements, so per-context
+	// passwords must be patched manually after unmarshal.
+	// Env var pattern: MIR__CTX__<UPPERCASE_CONTEXT_NAME>__PASSWORD
+	// e.g. context "local" → MIR__CTX__LOCAL__PASSWORD
+	for i := range cfg.Contexts {
+		key := "MIR__CTX__" + strings.ToUpper(strings.ReplaceAll(cfg.Contexts[i].Name, "-", "_")) + "__PASSWORD"
+		if val := os.Getenv(key); val != "" {
+			cfg.Contexts[i].Sec.Password = val
+		}
+	}
+
 	k.Bind(cfg)
 
 	if d.LogLevel != "" {

--- a/infra/k8s/charts/mir/Chart.yaml
+++ b/infra/k8s/charts/mir/Chart.yaml
@@ -3,8 +3,8 @@ name: mir
 description: A Helm chart for Mir IoT Platform for Kubernetes
 type: application
 
-version: 0.3.0
-appVersion: "v0.4.2"
+version: 0.4.0
+appVersion: "v0.8.2"
 
 dependencies:
   - name: nats

--- a/infra/k8s/charts/mir/secret/mir.secret.yaml
+++ b/infra/k8s/charts/mir/secret/mir.secret.yaml
@@ -7,3 +7,6 @@ stringData:
   MIR__SURREAL__USER: "root"
   MIR__SURREAL__PASSWORD: "root"
   MIR__INFLUX__TOKEN: "mir-operator-token"
+  # Per-context Cockpit passwords (pattern: MIR__CTX__<UPPERCASE_NAME>__PASSWORD)
+  # Hyphens in context names become underscores, e.g. "local-secret" → LOCAL_SECRET
+  # MIR__CTX__LOCAL__PASSWORD: "mir-operator"

--- a/infra/k8s/charts/mir/templates/mir/configmap.yaml
+++ b/infra/k8s/charts/mir/templates/mir/configmap.yaml
@@ -6,15 +6,52 @@ metadata:
   labels:
     {{- include "mir.labels" . | nindent 4 }}
 data:
+  cli.yaml: |
+    contexts:
+      {{- range .Values.config.contexts }}
+      - name: {{ .name | quote }}
+        target: {{ .target | quote }}
+        webTarget: {{ .webTarget | quote }}
+        grafana: {{ .grafana | quote }}
+        sec:
+          credentials: {{ .sec.credentials | quote }}
+          rootCA: {{ .sec.rootCA | quote }}
+          tlsCert: {{ .sec.tlsCert | quote }}
+          tlsKey: {{ .sec.tlsKey | quote }}
+          password: {{ .sec.password | quote }}
+      {{- end }}
   mir.yaml: |
     mir:
+      logLevel: {{ .Values.config.mir.logLevel | quote }}
+      http:
+        port: {{ .Values.service.targetPort }}
+        tlsCert: ""
+        tlsKey: ""
+      core:
+        enabled: {{ .Values.config.mir.core.enabled }}
+        deviceOnlineFlush: {{ .Values.config.mir.core.deviceOnlineFlush | quote }}
+        deviceOfflineFlush: {{ .Values.config.mir.core.deviceOfflineFlush | quote }}
+        deviceOfflineAfter: {{ .Values.config.mir.core.deviceOfflineAfter | quote }}
+      prototlm:
+        enabled: {{ .Values.config.mir.prototlm.enabled }}
+      protocmd:
+        enabled: {{ .Values.config.mir.protocmd.enabled }}
+      protocfg:
+        enabled: {{ .Values.config.mir.protocfg.enabled }}
+      event:
+        enabled: {{ .Values.config.mir.event.enabled }}
+        flushInterval: {{ .Values.config.mir.event.flushInterval | quote }}
+      cockpit:
+        enabled: {{ .Values.config.mir.cockpit.enabled }}
+        allowedOrigins: {{ .Values.config.mir.cockpit.allowedOrigins }}
+        githubOwner: {{ .Values.config.mir.cockpit.githubOwner | quote }}
+        githubRepo: {{ .Values.config.mir.cockpit.githubRepo | quote }}
+    nats:
       {{- if .Values.config.mir.url }}
       url: {{ .Values.config.mir.url | quote }}
       {{- else }}
       url: "nats://{{ .Release.Name }}-nats:4222"
       {{- end }}
-      logLevel: {{ .Values.config.mir.logLevel | quote }}
-      httpPort: {{ .Values.service.targetPort }}
       {{- if .Values.authSecretRef }}
       credentials: "/etc/mir/mir.creds"
       {{- end }}

--- a/infra/k8s/charts/mir/templates/mir/configmap.yaml
+++ b/infra/k8s/charts/mir/templates/mir/configmap.yaml
@@ -14,7 +14,7 @@ data:
         webTarget: {{ .webTarget | quote }}
         grafana: {{ .grafana | quote }}
         sec:
-          credentials: {{ .sec.credentials | quote }}
+          credentials: {{ if .sec.credsSecretRef }}{{ printf "/etc/mir/creds/%s.creds" .name | quote }}{{ else }}{{ .sec.credentials | quote }}{{ end }}
           rootCA: {{ .sec.rootCA | quote }}
           tlsCert: {{ .sec.tlsCert | quote }}
           tlsKey: {{ .sec.tlsKey | quote }}

--- a/infra/k8s/charts/mir/templates/mir/configmap.yaml
+++ b/infra/k8s/charts/mir/templates/mir/configmap.yaml
@@ -25,8 +25,13 @@ data:
       logLevel: {{ .Values.config.mir.logLevel | quote }}
       http:
         port: {{ .Values.service.targetPort }}
+        {{- if .Values.mirHttpTlsSecretRef }}
+        tlsCert: "/etc/mir/http-tls/tls.crt"
+        tlsKey: "/etc/mir/http-tls/tls.key"
+        {{- else }}
         tlsCert: ""
         tlsKey: ""
+        {{- end }}
       core:
         enabled: {{ .Values.config.mir.core.enabled }}
         deviceOnlineFlush: {{ .Values.config.mir.core.deviceOnlineFlush | quote }}

--- a/infra/k8s/charts/mir/templates/mir/deployment.yaml
+++ b/infra/k8s/charts/mir/templates/mir/deployment.yaml
@@ -60,13 +60,18 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- $scheme := .Values.mirHttpTlsSecretRef | empty | ternary "HTTP" "HTTPS" }}
           {{- with .Values.livenessProbe }}
+          {{- $probe := deepCopy . }}
+          {{- $_ := set $probe.httpGet "scheme" $scheme }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $probe | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
+          {{- $probe := deepCopy . }}
+          {{- $_ := set $probe.httpGet "scheme" $scheme }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $probe | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
@@ -85,6 +90,16 @@ spec:
             - name: auth
               mountPath: /etc/mir/mir.creds
               subPath: mir.creds
+              readOnly: true
+            {{- end }}
+            {{- with .Values.mirHttpTlsSecretRef }}
+            - name: mir-http-tls
+              mountPath: /etc/mir/http-tls/tls.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: mir-http-tls
+              mountPath: /etc/mir/http-tls/tls.key
+              subPath: tls.key
               readOnly: true
             {{- end }}
             {{- if or .Values.caSecretRef .Values.tlsSecretRef }}
@@ -121,6 +136,11 @@ spec:
             name: {{ include "mir.fullname" . }}-config
         {{- with .Values.authSecretRef }}
         - name: auth
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- with .Values.mirHttpTlsSecretRef }}
+        - name: mir-http-tls
           secret:
             secretName: {{ . }}
         {{- end }}

--- a/infra/k8s/charts/mir/templates/mir/deployment.yaml
+++ b/infra/k8s/charts/mir/templates/mir/deployment.yaml
@@ -102,11 +102,13 @@ spec:
               subPath: tls.key
               readOnly: true
             {{- end }}
-            {{- if or .Values.caSecretRef .Values.tlsSecretRef }}
+            {{- if .Values.caSecretRef }}
             - name: mir-certs
               mountPath: /etc/mir/ca.crt
               subPath: ca.crt
               readOnly: true
+            {{- end }}
+            {{- if .Values.tlsSecretRef }}
             - name: mir-certs
               mountPath: /etc/mir/tls.crt
               subPath: tls.crt

--- a/infra/k8s/charts/mir/templates/mir/deployment.yaml
+++ b/infra/k8s/charts/mir/templates/mir/deployment.yaml
@@ -101,6 +101,14 @@ spec:
               subPath: tls.key
               readOnly: true
             {{- end }}
+            {{- range .Values.config.contexts }}
+            {{- if .sec.credsSecretRef }}
+            - name: {{ printf "ctx-creds-%s" (.name | lower | replace "." "-" | replace "_" "-") }}
+              mountPath: {{ printf "/etc/mir/creds/%s.creds" .name }}
+              subPath: {{ default "mir.creds" .sec.credsSecretKey }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -136,6 +144,13 @@ spec:
                 - key: tls.key
                   path: tls.key
             {{- end }}
+        {{- end }}
+        {{- range .Values.config.contexts }}
+        {{- if .sec.credsSecretRef }}
+        - name: {{ printf "ctx-creds-%s" (.name | lower | replace "." "-" | replace "_" "-") }}
+          secret:
+            secretName: {{ .sec.credsSecretRef }}
+        {{- end }}
         {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/infra/k8s/charts/mir/templates/mir/deployment.yaml
+++ b/infra/k8s/charts/mir/templates/mir/deployment.yaml
@@ -77,6 +77,10 @@ spec:
               mountPath: /etc/mir/mir.yaml
               subPath: mir.yaml
               readOnly: true
+            - name: contexts
+              mountPath: /etc/mir/cli.yaml
+              subPath: cli.yaml
+              readOnly: true
             {{- with .Values.authSecretRef }}
             - name: auth
               mountPath: /etc/mir/mir.creds
@@ -102,6 +106,9 @@ spec:
           {{- end }}
       volumes:
         - name: config
+          configMap:
+            name: {{ include "mir.fullname" . }}-config
+        - name: contexts
           configMap:
             name: {{ include "mir.fullname" . }}-config
         {{- with .Values.authSecretRef }}

--- a/infra/k8s/charts/mir/templates/nats/ingress.yaml
+++ b/infra/k8s/charts/mir/templates/nats/ingress.yaml
@@ -35,4 +35,16 @@ spec:
                 name: {{ include "mir.fullname" . }}-nats-monitor
                 port:
                   number: 8222
+    {{- if .Values.nats.ingress.wsHost }}
+    - host: {{ .Values.nats.ingress.wsHost | quote }}
+      http:
+        paths:
+          - path: {{ .Values.nats.ingress.wsPath | default "/nats-ws" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ printf "%s-nats" .Release.Name }}
+                port:
+                  number: 9222
+    {{- end }}
 {{- end }}

--- a/infra/k8s/charts/mir/templates/nats/ingress.yaml
+++ b/infra/k8s/charts/mir/templates/nats/ingress.yaml
@@ -35,16 +35,4 @@ spec:
                 name: {{ include "mir.fullname" . }}-nats-monitor
                 port:
                   number: 8222
-    {{- if .Values.nats.ingress.wsHost }}
-    - host: {{ .Values.nats.ingress.wsHost | quote }}
-      http:
-        paths:
-          - path: {{ .Values.nats.ingress.wsPath | default "/nats-ws" }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ printf "%s-nats" .Release.Name }}
-                port:
-                  number: 9222
-    {{- end }}
 {{- end }}

--- a/infra/k8s/charts/mir/values-full.yaml
+++ b/infra/k8s/charts/mir/values-full.yaml
@@ -36,6 +36,7 @@ config:
       webTarget: ""       # Set to ws://<host>/nats-ws or ws://<host>:31922
       grafana: ""         # Set to http://<grafana-host>
       sec:
+        credsSecretRef: ""
         credentials: ""
         rootCA: ""
         tlsCert: ""

--- a/infra/k8s/charts/mir/values-full.yaml
+++ b/infra/k8s/charts/mir/values-full.yaml
@@ -30,6 +30,17 @@ image:
 ##     MIR__INFLUX__TOKEN: "mir-operator-token"
 #secretRef: mir-secret
 config:
+  contexts:
+    - name: "default"
+      target: ""          # Set to nats://<cluster-ip>:31422
+      webTarget: ""       # Set to ws://<host>/nats-ws or ws://<host>:31922
+      grafana: ""         # Set to http://<grafana-host>
+      sec:
+        credentials: ""
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
   mir:
     # NATS URL - automatically configured
     url: ""  # Auto-configured
@@ -128,7 +139,7 @@ nats:
   ingress:
     enabled: false
     className: ""
-    annotations:{}
+    annotations: {}
     host: nats.example.com
     path: /
     pathType: Prefix
@@ -136,6 +147,8 @@ nats:
       - secretName: nats-tls
         hosts:
           - nats.example.com
+    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
+    wsPath: /nats-ws
 
   # NATS cluster configuration
   config:

--- a/infra/k8s/charts/mir/values-full.yaml
+++ b/infra/k8s/charts/mir/values-full.yaml
@@ -148,8 +148,15 @@ nats:
       - secretName: nats-tls
         hosts:
           - nats.example.com
-    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
-    wsPath: /nats-ws
+  # config:
+  #   websocket:
+  #     ingress:
+  #       enabled: true
+  #       hosts:
+  #         - mir.example.com
+  #       path: /nats-ws
+  #       pathType: Prefix
+  #       className: ""   # nginx, traefik, etc.
 
   # NATS cluster configuration
   config:

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "cockpit__k8s--830f293"
+  tag: "cockpit__k8s--d3c88cb"
 
 config:
   contexts:
@@ -24,11 +24,31 @@ config:
         tlsCert: ""
         tlsKey: ""
         password: ""
+    - name: "local-secret-wss"
+      target: "nats://localhost:31422"
+      webTarget: "wss://localhost:31922"
+      grafana: "http://grafana-local:8081"
+      sec:
+        credsSecretRef: "mir-auth-secret-local-cockpit"           # K8s secret name containing the .creds file
+        credsSecretKey: "mir.creds"  # key inside the secret (default: mir.creds)
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
     - name: "local-ingress"
       target: "nats://localhost:31422"
       webTarget: "ws://mir-local:8081/nats-ws"
       grafana: "http://grafana-local:8081"
-      sec: {}
+      sec:
+        credsSecretRef: "mir-auth-secret-local-cockpit"           # K8s secret name containing the .creds file
+        credsSecretKey: "mir.creds"  # key inside the secret (default: mir.creds)
+    - name: "local-ingress-wss"
+      target: "nats://localhost:31422"
+      webTarget: "wss://mir-local:8081/nats-ws"
+      grafana: "http://grafana-local:8081"
+      sec:
+        credsSecretRef: "mir-auth-secret-local-cockpit"           # K8s secret name containing the .creds file
+        credsSecretKey: "mir.creds"  # key inside the secret (default: mir.creds)
   mir:
     logLevel: "debug"
 
@@ -54,8 +74,15 @@ nats:
     host: nats-local
     path: /
     pathType: Prefix
-    wsHost: mir-local
-    wsPath: /nats-ws
+  config:
+    websocket:
+      ingress:
+        enabled: true
+        hosts:
+          - mir-local
+        path: /nats-ws
+        pathType: Prefix
+        className: traefik
   promExporter:
     podMonitor:
       enabled: false

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -32,6 +32,9 @@ config:
   mir:
     logLevel: "debug"
 
+service:
+  type: NodePort
+
 ingress:
   enabled: true
   className: "traefik"

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -1,7 +1,18 @@
 image:
-  tag: "feature__nkeys-infra--5cd7553"
+  tag: "cockpit__k8s--560d94e"
 
 config:
+  contexts:
+    - name: "local"
+      target: "nats://localhost:31422"
+      webTarget: "ws://localhost:31922"
+      grafana: "http://grafana-local:8081"
+      sec:
+        credentials: ""
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
   mir:
     logLevel: "debug"
 
@@ -24,17 +35,20 @@ nats:
     host: nats-local
     path: /
     pathType: Prefix
-  service:
-    merge:
-      spec:
-        type: LoadBalancer
-        ports:
-          - appProtocol: tcp
-            name: nats
-            nodePort: 31422
-            port: 4222
-            protocol: TCP
-            targetPort: nats
+  # service:
+  #   merge:
+  #     spec:
+  #       type: LoadBalancer
+  #       ports:
+  #         - appProtocol: tcp
+  #           name: nats
+  #           nodePort: 31422
+  #           port: 4222
+  #           protocol: TCP
+  #           targetPort: nats
+  promExporter:
+    podMonitor:
+      enabled: false
 
 surrealdb:
   enabled: true
@@ -58,6 +72,13 @@ influxdb2:
     hostname: influx-local
     path: /
     tls: false
+
+# Disable monitoring CRDs (ServiceMonitor/PodMonitor) when prometheus stack is off
+mirServiceMonitors:
+  enabled: false
+
+mirPrometheusRules:
+  enabled: false
 
 # Enable Prometheus monitoring stack for k3d
 kube-prometheus-stack:

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -13,6 +13,11 @@ config:
         tlsCert: ""
         tlsKey: ""
         password: ""
+    - name: "local-ingress"
+      target: "nats://localhost:31422"
+      webTarget: "ws://mir-local:8081/nats-ws"
+      grafana: "http://grafana-local:8081"
+      sec: {}
   mir:
     logLevel: "debug"
 
@@ -35,6 +40,8 @@ nats:
     host: nats-local
     path: /
     pathType: Prefix
+    wsHost: mir-local
+    wsPath: /nats-ws
   # service:
   #   merge:
   #     spec:

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "cockpit__k8s--560d94e"
+  tag: "cockpit__k8s--207af5b"
 
 config:
   contexts:
@@ -8,11 +8,22 @@ config:
       webTarget: "ws://localhost:31922"
       grafana: "http://grafana-local:8081"
       sec:
-        credentials: ""
+        credentials: "/etc/mir/mir.creds"
         rootCA: ""
         tlsCert: ""
         tlsKey: ""
-        password: ""
+        password: "mir-operator"
+    - name: "local-secret"
+      target: "nats://localhost:31422"
+      webTarget: "ws://localhost:31922"
+      grafana: "http://grafana-local:8081"
+      sec:
+        credsSecretRef: "mir-auth-secret-local-cockpit"           # K8s secret name containing the .creds file
+        credsSecretKey: "mir.creds"  # key inside the secret (default: mir.creds)
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: "mir-operator"
     - name: "local-ingress"
       target: "nats://localhost:31422"
       webTarget: "ws://mir-local:8081/nats-ws"
@@ -42,17 +53,6 @@ nats:
     pathType: Prefix
     wsHost: mir-local
     wsPath: /nats-ws
-  # service:
-  #   merge:
-  #     spec:
-  #       type: LoadBalancer
-  #       ports:
-  #         - appProtocol: tcp
-  #           name: nats
-  #           nodePort: 31422
-  #           port: 4222
-  #           protocol: TCP
-  #           targetPort: nats
   promExporter:
     podMonitor:
       enabled: false

--- a/infra/k8s/charts/mir/values-local-k3d.yaml
+++ b/infra/k8s/charts/mir/values-local-k3d.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "cockpit__k8s--207af5b"
+  tag: "cockpit__k8s--830f293"
 
 config:
   contexts:
@@ -23,7 +23,7 @@ config:
         rootCA: ""
         tlsCert: ""
         tlsKey: ""
-        password: "mir-operator"
+        password: ""
     - name: "local-ingress"
       target: "nats://localhost:31422"
       webTarget: "ws://mir-local:8081/nats-ws"

--- a/infra/k8s/charts/mir/values-minimal.yaml
+++ b/infra/k8s/charts/mir/values-minimal.yaml
@@ -26,6 +26,17 @@ image:
 ##     MIR__INFLUX__TOKEN: "mir-operator-token"
 #secretRef: mir-secret
 config:
+  contexts:
+    - name: "default"
+      target: "nats://your-nats-server:4222"       # NATS TCP for CLI/devices
+      webTarget: "ws://your-nats-server:9222"       # NATS WebSocket for Cockpit
+      grafana: ""
+      sec:
+        credentials: ""
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
   mir:
     # External NATS URL - update to your NATS instance
     url: "nats://your-nats-server:4222/"
@@ -102,6 +113,16 @@ mirPromDashboards:
 ##
 nats:
   enabled: false
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    host: nats.example.com
+    path: /
+    pathType: Prefix
+    tls: []
+    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
+    wsPath: /nats-ws
 
 surrealdb:
   enabled: false

--- a/infra/k8s/charts/mir/values-minimal.yaml
+++ b/infra/k8s/charts/mir/values-minimal.yaml
@@ -32,6 +32,7 @@ config:
       webTarget: "ws://your-nats-server:9222"       # NATS WebSocket for Cockpit
       grafana: ""
       sec:
+        credsSecretRef: ""
         credentials: ""
         rootCA: ""
         tlsCert: ""

--- a/infra/k8s/charts/mir/values-minimal.yaml
+++ b/infra/k8s/charts/mir/values-minimal.yaml
@@ -122,8 +122,15 @@ nats:
     path: /
     pathType: Prefix
     tls: []
-    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
-    wsPath: /nats-ws
+  # config:
+  #   websocket:
+  #     ingress:
+  #       enabled: true
+  #       hosts:
+  #         - mir.example.com
+  #       path: /nats-ws
+  #       pathType: Prefix
+  #       className: ""   # nginx, traefik, etc.
 
 surrealdb:
   enabled: false

--- a/infra/k8s/charts/mir/values-standard.yaml
+++ b/infra/k8s/charts/mir/values-standard.yaml
@@ -115,8 +115,15 @@ nats:
     path: /
     pathType: Prefix
     tls: []
-    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
-    wsPath: /nats-ws
+  # config:
+  #   websocket:
+  #     ingress:
+  #       enabled: true
+  #       hosts:
+  #         - mir.example.com
+  #       path: /nats-ws
+  #       pathType: Prefix
+  #       className: ""   # nginx, traefik, etc.
 
   # NATS cluster configuration
   config:

--- a/infra/k8s/charts/mir/values-standard.yaml
+++ b/infra/k8s/charts/mir/values-standard.yaml
@@ -34,6 +34,7 @@ config:
       webTarget: ""       # Set to ws://<host>/nats-ws or ws://<host>:31922
       grafana: ""
       sec:
+        credsSecretRef: ""
         credentials: ""
         rootCA: ""
         tlsCert: ""

--- a/infra/k8s/charts/mir/values-standard.yaml
+++ b/infra/k8s/charts/mir/values-standard.yaml
@@ -28,6 +28,17 @@ image:
 ##     MIR__INFLUX__TOKEN: "mir-operator-token"
 #secretRef: mir-secret
 config:
+  contexts:
+    - name: "default"
+      target: ""          # Set to nats://<cluster-ip>:31422
+      webTarget: ""       # Set to ws://<host>/nats-ws or ws://<host>:31922
+      grafana: ""
+      sec:
+        credentials: ""
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
   mir:
     # NATS URL - automatically set when nats.enabled=true
     url: ""
@@ -103,6 +114,8 @@ nats:
     path: /
     pathType: Prefix
     tls: []
+    wsHost: ""          # Set to expose NATS WebSocket via ingress (e.g. mir.example.com)
+    wsPath: /nats-ws
 
   # NATS cluster configuration
   config:

--- a/infra/k8s/charts/mir/values-tls.yaml
+++ b/infra/k8s/charts/mir/values-tls.yaml
@@ -1,37 +1,69 @@
-## Quick Setup
-# 1. NATS TLS Secret
-# kubectl create secret tls <NATS_TLS_SECRET> --cert=tls.crt --key=tls.key
-# 2. NATS CA Secret (Mutual TLS)
-# kubectl create secret generic <NATS_CA_SECRET> --from-file=ca.crt=ca.crt
-# 3. Mir CA Secret
-# kubectl create secret generic <MIR_CA_SECRET> --from-file=ca.crt=ca.crt
-# 4. Mir TLS Secret (Mutual TLS)
-# kubectl create secret tls <MIR_TLS_SECRET> --cert=tls.crt --key=tls.key
+## TLS for Mir Kubernetes Deployment
+## See book/src/security/tls-kubernetes.md for the full guide.
+
+## ─────────────────────────────────────────────────────────────
+## MIR SERVER HTTPS
+## ─────────────────────────────────────────────────────────────
+
+## Option A and B are MUTUALLY EXCLUSIVE.
+## Choose one based on your setup:
+##   Option A — you have an ingress controller (recommended for most deployments).
+##              Do NOT set mirHttpTlsSecretRef — ingress forwards plain HTTP to the pod.
+##   Option B — no ingress. The pod serves HTTPS directly.
+##              Setting ingress.enabled=true with mirHttpTlsSecretRef will break routing
+##              because the ingress always forwards plain HTTP to the backend.
+
+## Option A: Via Ingress (TLS terminated at ingress, Mir runs plain HTTP internally)
+## kubectl create secret tls <MIR_INGRESS_TLS_SECRET> --cert=tls.crt --key=tls.key
+## kubectl create secret tls <MIR_INGRESS_TLS_SECRET> --cert=tls.crt --key=tls.key --dry-run=client -o yaml > mir-tls.secret.yaml
 ##
+# ingress:
+#   enabled: true
+#   className: "traefik"  # or "nginx", etc.
+#   tls:
+#     - secretName: <MIR_INGRESS_TLS_SECRET>
+#       hosts:
+#         - <MIR_HOST>
 
-## NATS
-nats:
-  config:
-    nats:
-      tls:
-        enabled: true
-        secretName: <NATS_TLS_SECRET>
-        dir: /etc/nats-certs
-        cert: tls.crt
-        key: tls.key
-        merge:
-          verify: true # True for Mutual TLS, false for ServerOnly TLS
-          timeout: 2
-  # Reference CA for mTLS
-  tlsCA:
-    enabled: true
-    secretName: <NATS_CA_SECRET>
-    dir: /etc/nats-ca-certs
-    key: ca.crt
+## Option B: Via App (Mir pod runs HTTPS directly, see ./secret/mir-tls.secret.yaml)
+## kubectl create secret tls <MIR_HTTP_TLS_SECRET> --cert=tls.crt --key=tls.key
+## kubectl create secret tls <MIR_HTTP_TLS_SECRET> --cert=tls.crt --key=tls.key --dry-run=client -o yaml > mir-tls.secret.yaml
+##
+# mirHttpTlsSecretRef: <MIR_HTTP_TLS_SECRET>
 
-## MIR
-# Configure Mir Server Access, see
-# - ./secret/mir-ca.secret.yaml
-# - ./secret/mir-tls.secret.yaml
-caSecretRef: <MIR_CA_SECRET>
-tlsSecretRef: <MIR_TLS_SECRET>
+## ─────────────────────────────────────────────────────────────
+## NATS TLS (app-level — Mir connects to NATS over TLS)
+## ─────────────────────────────────────────────────────────────
+## See tls-serveronly.md / tls-mutual.md for NATS TLS configuration.
+##
+## 1. NATS TLS Secret
+## kubectl create secret tls <NATS_TLS_SECRET> --cert=tls.crt --key=tls.key
+## 2. NATS CA Secret (Mutual TLS)
+## kubectl create secret generic <NATS_CA_SECRET> --from-file=ca.crt=ca.crt
+## 3. Mir CA Secret (to verify NATS certificate)
+## kubectl create secret generic <MIR_CA_SECRET> --from-file=ca.crt=ca.crt
+## 4. Mir TLS Secret (Mutual TLS client cert for Mir → NATS)
+## kubectl create secret tls <MIR_TLS_SECRET> --cert=tls.crt --key=tls.key
+##
+# nats:
+#   config:
+#     nats:
+#       tls:
+#         enabled: true
+#         secretName: <NATS_TLS_SECRET>
+#         dir: /etc/nats-certs
+#         cert: tls.crt
+#         key: tls.key
+#         merge:
+#           verify: true # true = Mutual TLS, false = Server-Only TLS
+#           timeout: 2
+#   tlsCA:
+#     enabled: true
+#     secretName: <NATS_CA_SECRET>
+#     dir: /etc/nats-ca-certs
+#     key: ca.crt
+#
+## Mir server verifies NATS certificate (Server-Only and mTLS):
+# caSecretRef: <MIR_CA_SECRET>
+## Mir server presents client cert (mTLS only):
+# tlsSecretRef: <MIR_TLS_SECRET>

--- a/infra/k8s/charts/mir/values-tls.yaml
+++ b/infra/k8s/charts/mir/values-tls.yaml
@@ -1,5 +1,5 @@
 ## TLS for Mir Kubernetes Deployment
-## See book/src/security/tls-kubernetes.md for the full guide.
+## See book/src/security/tls-serveronly.md or tls-mutual.md for the full guide.
 
 ## ─────────────────────────────────────────────────────────────
 ## MIR SERVER HTTPS
@@ -55,7 +55,7 @@
 #         cert: tls.crt
 #         key: tls.key
 #         merge:
-#           verify: true # true = Mutual TLS, false = Server-Only TLS
+#           verify: false # true = Mutual TLS, false = Server-Only TLS
 #           timeout: 2
 #   tlsCA:
 #     enabled: true
@@ -67,3 +67,41 @@
 # caSecretRef: <MIR_CA_SECRET>
 ## Mir server presents client cert (mTLS only):
 # tlsSecretRef: <MIR_TLS_SECRET>
+
+## ─────────────────────────────────────────────────────────────
+## NATS WEBSOCKET TLS
+## ─────────────────────────────────────────────────────────────
+## The browser requires wss:// when Cockpit is served over HTTPS.
+## Option A and B are MUTUALLY EXCLUSIVE — choose one.
+## Make sure to configure webTarget with wss: "wss://<MIR_HOST>/nats-ws"
+
+## Option A: Via Ingress (matches Mir Server HTTPS Option A)
+## TLS terminated at the ingress. NATS WebSocket runs plain WS internally.
+## Use the same TLS secret as the Mir ingress.
+## kubectl create secret tls <MIR_HTTP_TLS_SECRET> --cert=tls.crt --key=tls.key
+##
+# nats:
+#   config:
+#     websocket:
+#       ingress:
+#         enabled: true
+#         hosts:
+#           - <MIR_HOST>
+#         path: /nats-ws
+#         pathType: Prefix
+#         className: traefik        # or nginx, etc.
+#         tlsSecretName: <MIR_HTTP_TLS_SECRET>
+
+## Option B: Via NATS directly (matches Mir Server HTTPS Option B — no ingress)
+## NATS WebSocket serves WSS on NodePort 31922. Cannot combine with WebSocket ingress.
+## kubectl create secret tls <NATS_WS_TLS_SECRET> --cert=tls.crt --key=tls.key
+##
+# nats:
+#   config:
+#     websocket:
+#       tls:
+#         enabled: true
+#         secretName: <NATS_WS_TLS_SECRET>
+#         dir: /etc/nats-certs/websocket
+#         cert: tls.crt
+#         key: tls.key

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -19,6 +19,14 @@ config:
       webTarget: ""
       grafana: ""
       sec:
+        ## Option 1: reference a dedicated per-context secret (auto-mounts the file).
+        ## kubectl create secret generic mir-ctx-creds --from-file=mir.creds=./ctx.creds
+        credsSecretRef: ""           # K8s secret name containing the .creds file
+        credsSecretKey: "mir.creds"  # key inside the secret (default: mir.creds)
+        ## Option 2: point to an already-mounted path, e.g. the Mir server's own
+        ## NATS credentials file that is mounted via authSecretRef at /etc/mir/mir.creds.
+        ## authSecretRef: mir-auth-secret  (server-level, mounts /etc/mir/mir.creds)
+        ## credentials: "/etc/mir/mir.creds"
         credentials: ""
         rootCA: ""
         tlsCert: ""

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -134,6 +134,7 @@ nats:
             port: 9222
             protocol: TCP
             targetPort: websocket
+  # HTTP Ingress for Nats Monitoring
   ingress:
     enabled: false
     className: ""  # "[nginx|traefik]"
@@ -145,12 +146,19 @@ nats:
     #  - secretName: nats-tls
     #    hosts:
     #      - nats-local
-    wsHost: ""       # host to expose NATS WebSocket via ingress (empty = disabled)
-    wsPath: /nats-ws
   config:
     websocket:
       enabled: true
       port: 9222
+      ## Expose WebSocket via ingress.
+      # ingress:
+      #   enabled: true
+      #   hosts:
+      #     - mir.example.com       # same host as Mir ingress
+      #   path: /nats-ws
+      #   pathType: Prefix
+      #   className: traefik        # or nginx, etc.
+      #   tlsSecretName: ""
       tls:
         enabled: false
         # set secretName in order to mount an existing secret to dir

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -3,6 +3,11 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+## TLS secret for the Mir HTTP server (enables HTTPS on the Mir API/Cockpit endpoint).
+## kubectl create secret tls <name> --cert=tls.crt --key=tls.key
+## Refer to chart ./secret/mir-tls.secret.yaml
+#mirHttpTlsSecretRef: mir-http-tls-secret
+
 ## Use secret to pass any config as environment variables, mainly passwords and tokens.
 ## Refer to chart ./secret/mir.secret.yaml
 ## eg:
@@ -28,9 +33,6 @@ config:
         ## authSecretRef: mir-auth-secret  (server-level, mounts /etc/mir/mir.creds)
         ## credentials: "/etc/mir/mir.creds"
         credentials: ""
-        rootCA: ""
-        tlsCert: ""
-        tlsKey: ""
         ## Inject password via the existing secretRef secret to avoid plaintext in values.
         ## Add a key MIR__CTX__<UPPERCASE_NAME>__PASSWORD to the secret referenced by secretRef.
         ## e.g. for context "local":  MIR__CTX__LOCAL__PASSWORD: "mypassword"

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -13,10 +13,41 @@ image:
 ##     MIR__INFLUX__TOKEN: "mir-operator-token"
 #secretRef: mir-secret
 config:
+  contexts:
+    - name: "local"
+      target: ""
+      webTarget: ""
+      grafana: ""
+      sec:
+        credentials: ""
+        rootCA: ""
+        tlsCert: ""
+        tlsKey: ""
+        password: ""
   mir:
+    logLevel: "info"
+    core:
+      enabled: true
+      deviceOnlineFlush: 7s
+      deviceOfflineFlush: 12s
+      deviceOfflineAfter: 30s
+    prototlm:
+      enabled: true
+    protocmd:
+      enabled: true
+    protocfg:
+      enabled: true
+    event:
+      enabled: true
+      flushInterval: 5s
+    cockpit:
+      enabled: true
+      allowedOrigins: []
+      githubOwner: "MaxThom"
+      githubRepo: "mir"
+  nats:
     # NATS URL - automatically set with release name when empty
     url: "" # nats://localhost:4222/
-    logLevel: "info"
   surreal:
     # SURREAL URL - automatically set with release name when empty
     url: "" # ws://localhost:8000/
@@ -83,6 +114,12 @@ nats:
             port: 4222
             protocol: TCP
             targetPort: nats
+          - appProtocol: tcp
+            name: websocket
+            nodePort: 31922
+            port: 9222
+            protocol: TCP
+            targetPort: websocket
   ingress:
     enabled: false
     className: ""  # "[nginx|traefik]"
@@ -95,6 +132,16 @@ nats:
     #    hosts:
     #      - nats-local
   config:
+    websocket:
+      enabled: true
+      port: 9222
+      tls:
+        enabled: false
+        # set secretName in order to mount an existing secret to dir
+        secretName: ""
+        dir: /etc/nats-certs/websocket
+        cert: tls.crt
+        key: tls.key
     merge:
       max_payload: << 8MB >>
     cluster:
@@ -146,7 +193,6 @@ surrealdb:
     size: 10Gi
     storageClassName: ""
   podSecurityContext:
-    podSecurityContext:
     runAsUser: 999
     runAsGroup: 999
     fsGroup: 999

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -131,6 +131,8 @@ nats:
     #  - secretName: nats-tls
     #    hosts:
     #      - nats-local
+    wsHost: ""       # host to expose NATS WebSocket via ingress (empty = disabled)
+    wsPath: /nats-ws
   config:
     websocket:
       enabled: true

--- a/infra/k8s/charts/mir/values.yaml
+++ b/infra/k8s/charts/mir/values.yaml
@@ -31,6 +31,10 @@ config:
         rootCA: ""
         tlsCert: ""
         tlsKey: ""
+        ## Inject password via the existing secretRef secret to avoid plaintext in values.
+        ## Add a key MIR__CTX__<UPPERCASE_NAME>__PASSWORD to the secret referenced by secretRef.
+        ## e.g. for context "local":  MIR__CTX__LOCAL__PASSWORD: "mypassword"
+        ## e.g. for "local-secret":   MIR__CTX__LOCAL_SECRET__PASSWORD: "mypassword"
         password: ""
   mir:
     logLevel: "info"

--- a/infra/k8s/k3d/k3d_config.yaml
+++ b/infra/k8s/k3d/k3d_config.yaml
@@ -12,6 +12,13 @@ ports:
   - port: 8081:80
     nodeFilters:
       - loadbalancer
+  - port: 8083:443
+    nodeFilters:
+      - loadbalancer
+  # Mir
+  - port: 30015:30015
+    nodeFilters:
+      - loadbalancer
   # Nats
   - port: 31422:31422
     nodeFilters:

--- a/infra/k8s/k3d/k3d_config.yaml
+++ b/infra/k8s/k3d/k3d_config.yaml
@@ -16,6 +16,9 @@ ports:
   - port: 31422:31422
     nodeFilters:
       - loadbalancer
+  - port: 31922:31922
+    nodeFilters:
+      - loadbalancer
 registries:
   config: |
     configs:

--- a/internal/servers/cockpit_srv/spa_handler.go
+++ b/internal/servers/cockpit_srv/spa_handler.go
@@ -10,7 +10,7 @@ import (
 )
 
 // createSPAHandler creates a handler for serving a SPA
-// It serves static files if they exist, otherwise falls back to index.html
+// It serves static files if they exist, otherwise falls back to 200.html
 func createSPAHandler(webFS fs.FS, log zerolog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Clean the path
@@ -38,16 +38,20 @@ func createSPAHandler(webFS fs.FS, log zerolog.Logger) http.Handler {
 			}
 		}
 
-		// File doesn't exist or is a directory, serve index.html for SPA routing
-		indexData, err := fs.ReadFile(webFS, "index.html")
+		// File doesn't exist or is a directory, serve 200.html for SPA routing.
+		// 200.html uses absolute asset paths and a fixed empty base, so it works
+		// correctly when served for any URL depth (e.g. /devices/gimli).
+		// index.html uses relative paths and a runtime-computed base that breaks
+		// for nested routes.
+		indexData, err := fs.ReadFile(webFS, "200.html")
 		if err != nil {
-			log.Error().Err(err).Msg("failed to read index.html")
+			log.Error().Err(err).Msg("failed to read 200.html")
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate") // Don't cache index.html
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate") // Don't cache 200.html
 		w.WriteHeader(http.StatusOK)
 		w.Write(indexData)
 	})

--- a/internal/ui/web/src/app.html
+++ b/internal/ui/web/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<base href="/" />
 		<link rel="icon" type="image/png" sizes="16x16" href="/mir_alpha.png" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/mir_alpha.png" />
 		%sveltekit.head%

--- a/internal/ui/web/src/lib/domains/activity/stores/activity.svelte.ts
+++ b/internal/ui/web/src/lib/domains/activity/stores/activity.svelte.ts
@@ -4,7 +4,7 @@ export type ActivityKind = 'success' | 'error' | 'info';
 export type ActivityCategory = 'Device' | 'Command' | 'Config' | 'Connection' | 'Telemetry' | 'Dashboard';
 
 export type ActivityEntry = {
-	id: string;
+	id: number;
 	timestamp: Date;
 	kind: ActivityKind;
 	category: ActivityCategory;
@@ -14,11 +14,13 @@ export type ActivityEntry = {
 	error?: string;
 };
 
+let nextId = 0;
+
 class ActivityStore {
 	entries = $state<ActivityEntry[]>([]);
 
 	add(entry: Omit<ActivityEntry, 'id' | 'timestamp'>) {
-		this.entries.unshift({ id: crypto.randomUUID(), timestamp: new Date(), ...entry });
+		this.entries.unshift({ id: nextId++, timestamp: new Date(), ...entry });
 
 		const title = `${entry.category} · ${entry.title}`;
 		const opts = entry.error ? { description: entry.error } : undefined;

--- a/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
+++ b/internal/ui/web/src/lib/domains/dashboards/stores/dashboard.svelte.ts
@@ -235,7 +235,7 @@ class DashboardStore {
 		const existing = d.spec.widgets ?? [];
 		const bottomY = existing.reduce((max, w) => Math.max(max, w.y + w.h), 0);
 		const newWidget: Widget = {
-			id: crypto.randomUUID(),
+			id: Math.random().toString(36).slice(2),
 			type,
 			title,
 			config,

--- a/internal/ui/web/src/lib/domains/sidebar/components/security-status.svelte
+++ b/internal/ui/web/src/lib/domains/sidebar/components/security-status.svelte
@@ -19,14 +19,16 @@
 		<Tooltip.Trigger class="flex items-center gap-1 text-xs">
 			{#if isHttps}
 				<ShieldCheckIcon class="size-3.5 text-green-500" />
-				<span class="text-sidebar-foreground/70">HTTP</span>
+				<span class="text-sidebar-foreground/70">HTTPS</span>
 			{:else}
 				<ShieldAlertIcon class="size-3.5 text-yellow-500" />
-				<span class="text-sidebar-foreground/50">HTTP</span>
+				<span class="text-sidebar-foreground/50">HTTPS</span>
 			{/if}
 		</Tooltip.Trigger>
 		<Tooltip.Content side="top">
-			<span class="text-xs">{isHttps ? 'Cockpit served over HTTPS' : 'Cockpit served over HTTP'}</span>
+			<span class="text-xs"
+				>{isHttps ? 'Cockpit served over HTTPS' : 'Cockpit served over HTTP'}</span
+			>
 		</Tooltip.Content>
 	</Tooltip.Root>
 

--- a/justfile
+++ b/justfile
@@ -153,6 +153,11 @@ k3d-recreate: k3d-delete k3d-create
 k3d-mir instance="local":
     cd infra/k8s/charts/mir && helm install {{ instance }} . -f values-local-k3d.yaml
 
+# Cluster pre-requisites
+k3d-pre:
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+
 # Run Mir book for local documentation
 book:
     cd book && mdbook serve -p 5001


### PR DESCRIPTION
## Summary

- **Helm chart config & contexts**: Added new `config` and `context` fields to the Mir Helm chart; wired per-context credentials and SPA routing fix for k8s
- **NATS WebSocket ingress**: Added NATS WebSocket exposure via ingress and NodePort; refactored to use NATS chart's native `config.websocket.ingress` instead of custom ingress routes
- **Cockpit HTTPS (mirHttpTlsSecretRef)**: Added support for Mir pod serving HTTPS directly; health probes now conditionally use `scheme: HTTPS` when TLS is configured
- **NATS WebSocket TLS**: Both TLS options are now configurable — via ingress termination (Option A) or NATS serving WSS directly (Option B)
- **K8s auth documentation**: Updated authentication guide for Kubernetes deployments
- **Context password**: Added password field support with Kubernetes secret reference for Cockpit context list
- **TLS documentation**: Consolidated Kubernetes TLS guidance into `tls-serveronly.md` and `tls-mutual.md` (removed separate `tls-kubernetes.md`); added mutual exclusivity notes for ingress TLS vs app-level TLS; documented both WebSocket TLS options with full kubectl commands and context `webTarget` examples

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing Done
- [x] Manual tests on k3d cluster (NATS TCP NodePort, WebSocket NodePort, ingress routing, HTTPS Cockpit, wss:// connections)

## Related Issues
Closes #